### PR TITLE
feat: implement konsist test to validate buffer sizes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ plugins {
     alias(libs.plugins.ktlint)
     alias(libs.plugins.vanniktech.publish)
     alias(libs.plugins.dokka)
+    `jvm-test-suite`
 }
 
 allprojects {
@@ -56,6 +57,7 @@ subprojects {
     apply(plugin = "signing")
     apply(plugin = "org.jetbrains.dokka")
     apply(plugin = "org.jetbrains.kotlin.jvm")
+    apply(plugin = "jvm-test-suite")
 
     // Do not publish the 'group' modules, as they got nothing in them.
     if (exclusionRegex.matches(name)) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ ktlint = "12.1.0"
 jnagmp = "3.0.0"
 dokka = "1.9.20"
 mavenpublish = "0.28.0"
+konsist = "0.14.0"
 
 [libraries]
 netty-bom = { module = "io.netty:netty-bom", version.ref = "netty" }
@@ -25,6 +26,7 @@ junit-api = { module = "org.junit.jupiter:junit-jupiter-api" }
 junit-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
 junit-params = { module = "org.junit.jupiter:junit-jupiter-params" }
 junit-launcher = { module = "org.junit.platform:junit-platform-launcher", version = "1.10.2" }
+konsist = { module = "com.lemonappdev:konsist", version.ref = "konsist" }
 log4j-bom = { module = "org.apache.logging.log4j:log4j-bom", version.ref = "log4j" }
 log4j-core = { module = "org.apache.logging.log4j:log4j-core" }
 log4j-api = { module = "org.apache.logging.log4j:log4j-api" }

--- a/protocol/build.gradle.kts
+++ b/protocol/build.gradle.kts
@@ -7,6 +7,21 @@ dependencies {
     implementation(projects.compression)
 }
 
+testing {
+    suites {
+        register("konsistTest", JvmTestSuite::class) {
+            dependencies {
+                implementation(project())
+                implementation(libs.konsist)
+            }
+        }
+    }
+}
+
+tasks.named("check") {
+    dependsOn(testing.suites.named("konsistTest"))
+}
+
 mavenPublishing {
     pom {
         name = "RsProt Protocol"

--- a/protocol/osrs-222/osrs-222-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/prot/GameServerProt.kt
+++ b/protocol/osrs-222/osrs-222-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/prot/GameServerProt.kt
@@ -86,7 +86,7 @@ public enum class GameServerProt(
     // World entity packets
     CLEAR_ENTITIES(GameServerProtId.CLEAR_ENTITIES, 0),
     SET_ACTIVE_WORLD(GameServerProtId.SET_ACTIVE_WORLD, 4),
-    WORLDENTITY_INFO(GameServerProtId.WORLDENTITY_INFO, -2),
+    WORLDENTITY_INFO(GameServerProtId.WORLDENTITY_INFO, Prot.VAR_SHORT),
 
     // Map packets
     REBUILD_NORMAL(GameServerProtId.REBUILD_NORMAL, Prot.VAR_SHORT),

--- a/protocol/osrs-223/osrs-223-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/prot/GameServerProt.kt
+++ b/protocol/osrs-223/osrs-223-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/prot/GameServerProt.kt
@@ -86,7 +86,7 @@ public enum class GameServerProt(
     // World entity packets
     CLEAR_ENTITIES(GameServerProtId.CLEAR_ENTITIES, 0),
     SET_ACTIVE_WORLD(GameServerProtId.SET_ACTIVE_WORLD, 4),
-    WORLDENTITY_INFO(GameServerProtId.WORLDENTITY_INFO, -2),
+    WORLDENTITY_INFO(GameServerProtId.WORLDENTITY_INFO, Prot.VAR_SHORT),
 
     // Map packets
     REBUILD_NORMAL(GameServerProtId.REBUILD_NORMAL, Prot.VAR_SHORT),

--- a/protocol/src/konsistTest/kotlin/net/rsprot/protocol/BufferTest.kt
+++ b/protocol/src/konsistTest/kotlin/net/rsprot/protocol/BufferTest.kt
@@ -1,0 +1,89 @@
+package net.rsprot.protocol
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.container.KoScope
+import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
+import com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration
+import com.lemonappdev.konsist.api.declaration.KoPropertyDeclaration
+import com.lemonappdev.konsist.api.ext.list.enumConstants
+import com.lemonappdev.konsist.api.ext.list.withName
+import com.lemonappdev.konsist.api.ext.list.withParentInterfaceNamed
+import com.lemonappdev.konsist.api.ext.list.withTypeOf
+import com.lemonappdev.konsist.api.ext.list.withoutAnnotationNamed
+import org.junit.jupiter.api.DynamicContainer
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+
+class BufferTest {
+    @TestFactory
+    fun `buffer matches size`() =
+        Konsist
+            .scopeFromProject()
+            .classes()
+            .withName(ENUM_NAME)
+            .map { it.moduleName }
+            .map { module ->
+                DynamicContainer.dynamicContainer(
+                    module.substringAfterLast("/"),
+                    createDynamicTestsForModule(module),
+                )
+            }
+
+    private fun createDynamicTestsForModule(module: String): List<DynamicTest> {
+        val scope = Konsist.scopeFromModule(module)
+        val encoders =
+            scope
+                .classes()
+                .withParentInterfaceNamed(ENCODER_INTERFACE)
+                .withoutAnnotationNamed(IGNORED_CLASS_ANNOTATION)
+
+        return encoders.map { encoder ->
+            DynamicTest.dynamicTest(encoder.name) { encoder.validateEncoder(scope) }
+        }
+    }
+
+    private fun KoClassDeclaration.validateEncoder(scope: KoScope) {
+        val prot = properties().withTypeOf(ServerProt::class).first()
+        val declaredSize = fetchDeclaredEnumSize(prot, scope)
+        if (declaredSize.startsWith(DYNAMIC_SIZE_PREFIX)) {
+            // VAR_* are dynamic
+            return
+        }
+        val expectedSize = declaredSize.toInt()
+        val encodeMethod = functions().withName(ENCODE_METHOD).first()
+        val actualSize = encodeMethod.extractSize()
+        assert(
+            expectedSize == actualSize,
+            lazyMessage = { "Expected size of $expectedSize, actual $actualSize" },
+        )
+    }
+
+    private fun fetchDeclaredEnumSize(
+        prot: KoPropertyDeclaration,
+        scope: KoScope,
+    ): String {
+        val enumConstantName = prot.value!!.substringAfter("$ENUM_NAME.")
+        val enumConstant = scope.classes().enumConstants.withName(enumConstantName).first()
+        val declaredSize = enumConstant.arguments[1].value!!
+        return declaredSize
+    }
+
+    private fun KoFunctionDeclaration.extractSize(): Int {
+        return bufferRegex.findAll(text).sumOf {
+            when (val size = it.groups["size"]?.value) {
+                "CombinedId" -> COMBINED_ID_SIZE
+                else -> size?.toIntOrNull() ?: 0
+            }
+        }
+    }
+
+    companion object {
+        private val bufferRegex = "buffer\\.p(?<size>(\\d|CombinedId)+)(Alt\\d+)?".toRegex()
+        private const val ENUM_NAME = "GameServerProt"
+        private const val DYNAMIC_SIZE_PREFIX = "Prot.VAR_"
+        private const val ENCODE_METHOD = "encode"
+        private const val ENCODER_INTERFACE = "MessageEncoder"
+        private const val IGNORED_CLASS_ANNOTATION = "Consistent"
+        private const val COMBINED_ID_SIZE = 4
+    }
+}


### PR DESCRIPTION
This introduces [konsist](https://docs.konsist.lemonappdev.com/) (a static analyzer) in order to create a test suite to ensure that written buffer sizes (via `buffer.p*`) match the declared size. I've added the new suite (`konsistTest`) as a dependency of `check`, so it will automatically be ran alongside other check tasks.

A test container is created for each dynamically discovered module that defines a `GameServerProt` enum, and tests for each encoder are nested under it.

<img width="484" alt="Screenshot 2024-06-28 at 5 46 51 PM" src="https://github.com/blurite/rsprot/assets/14898331/0cb12d08-0c1d-4f44-9bd4-c5a1ce89c7b4">


notes:
- encoders annotated with `@Consistent` are ignored
- `CombinedId` methods are hardcoded to 4 bytes
- the expected size from the enum is naively grabbing the second argument
- if the expected size is dynamic (`-1` or `-2`), the test is marked successful without any validation
- if running repeatedly via gradle, the `konsistTest` suite will always be `up-to-date`. this is because the inputs are from different modules. to force a run, you'll need `--rerun-tasks` [konsist docs](https://docs.konsist.lemonappdev.com/advanced/isolate-konsist-tests#running-konsist-tests)