### PR TITLE
Change `SetMapFlag` category `LOW_PRIORITY_PROT` -> `HIGH_PRIORITY_PROT`

### DIFF
--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/misc/player/SetMapFlag.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/misc/player/SetMapFlag.kt
@@ -28,7 +28,7 @@ public class SetMapFlag private constructor(
     public val zInBuildArea: Int
         get() = coordInBuildArea.zInBuildArea
     override val category: ServerProtCategory
-        get() = GameServerProtCategory.LOW_PRIORITY_PROT
+        get() = GameServerProtCategory.HIGH_PRIORITY_PROT
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/misc/player/SetMapFlag.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/misc/player/SetMapFlag.kt
@@ -28,7 +28,7 @@ public class SetMapFlag private constructor(
     public val zInBuildArea: Int
         get() = coordInBuildArea.zInBuildArea
     override val category: ServerProtCategory
-        get() = GameServerProtCategory.LOW_PRIORITY_PROT
+        get() = GameServerProtCategory.HIGH_PRIORITY_PROT
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/misc/player/SetMapFlag.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/misc/player/SetMapFlag.kt
@@ -28,7 +28,7 @@ public class SetMapFlag private constructor(
     public val zInBuildArea: Int
         get() = coordInBuildArea.zInBuildArea
     override val category: ServerProtCategory
-        get() = GameServerProtCategory.LOW_PRIORITY_PROT
+        get() = GameServerProtCategory.HIGH_PRIORITY_PROT
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/misc/player/SetMapFlag.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/misc/player/SetMapFlag.kt
@@ -28,7 +28,7 @@ public class SetMapFlag private constructor(
     public val zInBuildArea: Int
         get() = coordInBuildArea.zInBuildArea
     override val category: ServerProtCategory
-        get() = GameServerProtCategory.LOW_PRIORITY_PROT
+        get() = GameServerProtCategory.HIGH_PRIORITY_PROT
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true


### PR DESCRIPTION
Using rsprox, we can see that `set_map_flag` has the same priority as zone prots as they are sent in the order they were originally flagged.
Example 1
```
	Tick 8	
		oploc1	id=1536, coord=(3014, 3220, 0)
		set_map_flag	coord=null
		set_map_flag	coord=null
		loc_del	coord=(3014, 3220, 0), shape=0, rotation=2
		loc_add_change	id=1535, coord=(3014, 3219, 0), shape=0, rotation=1
		synth_sound	id=60
```

Example 2
```
	Tick 584	
		oploc1	id=1536, coord=(3012, 3238, 0)
		set_map_flag	coord=null
		set_map_flag	coord=null
		loc_del	coord=(3012, 3238, 0), shape=0, rotation=0
		loc_add_change	id=1535, coord=(3012, 3239, 0), shape=0, rotation=3
		synth_sound	id=60
```