### PR TITLE
Fix/info packets

### DIFF
--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfo.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfo.kt
@@ -135,6 +135,7 @@ public class NpcInfo internal constructor(
      * This exception will be propagated further during the [toNpcInfoPacket] function call,
      * allowing the server to handle it properly at a per-player basis.
      */
+    @Volatile
     internal var exception: Exception? = null
 
     /**
@@ -145,6 +146,8 @@ public class NpcInfo internal constructor(
      * any memory leaks.
      */
     private var builtIntoPacket: Boolean = false
+
+    override fun isDestroyed(): Boolean = this.exception != null
 
     /**
      * Returns the backing byte buffer holding all the computed information.

--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfoProtocol.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfoProtocol.kt
@@ -75,6 +75,10 @@ public class NpcInfoProtocol(
      * @param info the npc info object to deallocate
      */
     public fun dealloc(info: NpcInfo) {
+        // Prevent returning a destroyed npc info object back into the pool
+        if (info.isDestroyed()) {
+            return
+        }
         npcInfoRepository.dealloc(info.localPlayerIndex)
     }
 

--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerAvatar.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerAvatar.kt
@@ -80,8 +80,32 @@ public class PlayerAvatar internal constructor(
             huffmanCodec,
         )
 
+    /**
+     * Whether this avatar is completed hidden from everyone else. Note that this completely skips
+     * sending any information to the client about this given avatar, it is not the same as soft
+     * hiding via the appearance extended info.
+     */
     internal var hidden: Boolean = false
 
+    /**
+     * The [PlayerInfoProtocol.cycleCount] when this avatar was allocated.
+     * We use this to determine whether to perform a re-synchronization of a player,
+     * which can happen when a player is deallocated and reallocated on the same cycle,
+     * which could result in other players not seeing any change take place. While rare,
+     * this possibility exists, and it could result in some rather odd bugs.
+     */
+    internal var allocateCycle: Int = PlayerInfoProtocol.cycleCount
+
+    /**
+     * Sets the avatar as hidden (or unhidden, depending on [hidden]). When hidden via this function,
+     * no information is transmitted to the clients about this avatar. It is a hard-hiding function,
+     * unlike the one via appearance extended info, which strictly only hides client-side, but all
+     * clients still receive information about the client existing.
+     * The benefit to this function is that no plugins or RuneLite implementations can snoop on other
+     * players that are meant to be hidden. The downside, however, is that because the client has no
+     * knowledge of that specific avatar whatsoever, un-hiding while the player is moving is not as
+     * smooth as with the appearance variant, since it first appears as if the player teleported in.
+     */
     public fun setHidden(hidden: Boolean) {
         this.hidden = hidden
     }

--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
@@ -613,6 +613,12 @@ public class PlayerInfo internal constructor(
         if (other.avatar.hidden) {
             return false
         }
+        // If the avatar was allocated on this cycle, ensure we remove (and potentially re-add later)
+        // this avatar. This is due to someone logging out and another player taking the avatar the same
+        // cycle - which would otherwise potentially go by unnoticed, with the client assuming nothing changed.
+        if (other.avatar.allocateCycle == PlayerInfoProtocol.cycleCount) {
+            return false
+        }
         val coord = other.avatar.currentCoord
         if (!coord.inDistance(this.avatar.currentCoord, this.avatar.resizeRange)) {
             return false
@@ -711,6 +717,7 @@ public class PlayerInfo internal constructor(
         this.oldSchoolClientType = oldSchoolClientType
         this.buildArea = BuildArea.INVALID
         avatar.reset()
+        this.avatar.allocateCycle = PlayerInfoProtocol.cycleCount
         lowResolutionIndices.fill(0)
         lowResolutionCount = 0
         highResolutionIndices.fill(0)

--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
@@ -150,6 +150,7 @@ public class PlayerInfo internal constructor(
      * This exception will be propagated further during the [toPacket] function call,
      * allowing the server to handle it properly at a per-player basis.
      */
+    @Volatile
     internal var exception: Exception? = null
 
     /**
@@ -173,6 +174,8 @@ public class PlayerInfo internal constructor(
      */
     @Throws(IllegalStateException::class)
     public fun backingBuffer(): ByteBuf = checkNotNull(buffer)
+
+    override fun isDestroyed(): Boolean = this.exception != null
 
     /**
      * Updates the build area of this player info object.

--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfoProtocol.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfoProtocol.kt
@@ -122,6 +122,7 @@ public class PlayerInfoProtocol(
         prepareExtendedInfo()
         putExtendedInfo()
         postUpdate()
+        cycleCount++
     }
 
     /**
@@ -258,5 +259,18 @@ public class PlayerInfoProtocol(
          */
         public const val PROTOCOL_CAPACITY: Int = 2048
         private val logger: InlineLogger = InlineLogger()
+
+        /**
+         * The number of Player info update cycles that have occurred.
+         * We need to track this to avoid a nasty bug with servers de-allocating + re-allocating
+         * an avatar on the same cycle, in a small area. The effective bug is that another player takes
+         * ones' avatar, which leads to info protocol thinking nothing has changed (assuming the new player
+         * is still within range of the old one, enough to be in high resolution).
+         *
+         * We solve this by forcibly removing a player from high resolution view if the avatar was
+         * allocated on current cycle. If the player is still within range, they will be re-added
+         * later on in the cycle via low resolution updates - but correctly this time around!
+         */
+        internal var cycleCount: Int = 0
     }
 }

--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfoProtocol.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfoProtocol.kt
@@ -101,6 +101,10 @@ public class PlayerInfoProtocol(
      * @param info the player info object
      */
     public fun dealloc(info: PlayerInfo) {
+        // Prevent returning a destroyed player info object back into the pool
+        if (info.isDestroyed()) {
+            return
+        }
         playerInfoRepository.dealloc(info.localIndex)
     }
 

--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/util/ReferencePooledObject.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/util/ReferencePooledObject.kt
@@ -30,4 +30,14 @@ public interface ReferencePooledObject {
      * during the [onAlloc], to ensure no work is 'wasted'.
      */
     public fun onDealloc()
+
+    /**
+     * Whether this reference pooled object is destroyed.
+     * A destroyed object will not be returned back to the pool and instead will be left off for the
+     * garbage collector to clean up in due time. This condition is only hit when there was some error
+     * thrown during the processing of a given info object. In order to mitigate potential future
+     * problems that might continue to stem from re-using this object, we discard it altogether.
+     * @return whether the info object is destroyed and should not be returned to the pool.
+     */
+    public fun isDestroyed(): Boolean
 }

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfo.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfo.kt
@@ -58,6 +58,7 @@ public class NpcInfo internal constructor(
      * This exception will be propagated further during the [toNpcInfoPacket] function call,
      * allowing the server to handle it properly at a per-player basis.
      */
+    @Volatile
     internal var exception: Exception? = null
 
     /**
@@ -65,6 +66,8 @@ public class NpcInfo internal constructor(
      * The root world is placed at the end of this array, however id -1 will be treated as the root.
      */
     internal val details: Array<NpcInfoWorldDetails?> = arrayOfNulls(WORLD_ENTITY_CAPACITY + 1)
+
+    override fun isDestroyed(): Boolean = this.exception != null
 
     /**
      * Updates the build area of a given world to the specified one.

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfoProtocol.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfoProtocol.kt
@@ -78,6 +78,10 @@ public class NpcInfoProtocol(
      * @param info the npc info object to deallocate
      */
     public fun dealloc(info: NpcInfo) {
+        // Prevent returning a destroyed npc info object back into the pool
+        if (info.isDestroyed()) {
+            return
+        }
         npcInfoRepository.dealloc(info.localPlayerIndex)
     }
 

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerAvatar.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerAvatar.kt
@@ -80,8 +80,32 @@ public class PlayerAvatar internal constructor(
             huffmanCodec,
         )
 
+    /**
+     * Whether this avatar is completed hidden from everyone else. Note that this completely skips
+     * sending any information to the client about this given avatar, it is not the same as soft
+     * hiding via the appearance extended info.
+     */
     internal var hidden: Boolean = false
 
+    /**
+     * The [PlayerInfoProtocol.cycleCount] when this avatar was allocated.
+     * We use this to determine whether to perform a re-synchronization of a player,
+     * which can happen when a player is deallocated and reallocated on the same cycle,
+     * which could result in other players not seeing any change take place. While rare,
+     * this possibility exists, and it could result in some rather odd bugs.
+     */
+    internal var allocateCycle: Int = PlayerInfoProtocol.cycleCount
+
+    /**
+     * Sets the avatar as hidden (or unhidden, depending on [hidden]). When hidden via this function,
+     * no information is transmitted to the clients about this avatar. It is a hard-hiding function,
+     * unlike the one via appearance extended info, which strictly only hides client-side, but all
+     * clients still receive information about the client existing.
+     * The benefit to this function is that no plugins or RuneLite implementations can snoop on other
+     * players that are meant to be hidden. The downside, however, is that because the client has no
+     * knowledge of that specific avatar whatsoever, un-hiding while the player is moving is not as
+     * smooth as with the appearance variant, since it first appears as if the player teleported in.
+     */
     public fun setHidden(hidden: Boolean) {
         this.hidden = hidden
     }

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
@@ -685,6 +685,12 @@ public class PlayerInfo internal constructor(
         if (other.avatar.hidden) {
             return false
         }
+        // If the avatar was allocated on this cycle, ensure we remove (and potentially re-add later)
+        // this avatar. This is due to someone logging out and another player taking the avatar the same
+        // cycle - which would otherwise potentially go by unnoticed, with the client assuming nothing changed.
+        if (other.avatar.allocateCycle == PlayerInfoProtocol.cycleCount) {
+            return false
+        }
         val coord = other.avatar.currentCoord
         if (!details.renderCoord.inDistance(coord, this.avatar.resizeRange)) {
             return false
@@ -801,6 +807,7 @@ public class PlayerInfo internal constructor(
         avatar.extendedInfo.localIndex = index
         this.oldSchoolClientType = oldSchoolClientType
         avatar.reset()
+        this.avatar.allocateCycle = PlayerInfoProtocol.cycleCount
         this.activeWorldId = ROOT_WORLD
         // There is always a root world!
         val rootDetails = protocol.detailsStorage.poll(ROOT_WORLD)

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
@@ -83,6 +83,7 @@ public class PlayerInfo internal constructor(
      * This exception will be propagated further during the [toPacket] function call,
      * allowing the server to handle it properly at a per-player basis.
      */
+    @Volatile
     internal var exception: Exception? = null
 
     /**
@@ -117,6 +118,8 @@ public class PlayerInfo internal constructor(
         invalidateAppearanceCache = false
         avatar.extendedInfo.invalidateAppearanceCache()
     }
+
+    override fun isDestroyed(): Boolean = this.exception != null
 
     /**
      * Sets an active world in which the player currently resides.

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfoProtocol.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfoProtocol.kt
@@ -107,6 +107,10 @@ public class PlayerInfoProtocol(
      * @param info the player info object
      */
     public fun dealloc(info: PlayerInfo) {
+        // Prevent returning a destroyed player info object back into the pool
+        if (info.isDestroyed()) {
+            return
+        }
         playerInfoRepository.dealloc(info.localIndex)
     }
 

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfoProtocol.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfoProtocol.kt
@@ -128,6 +128,7 @@ public class PlayerInfoProtocol(
         prepareExtendedInfo()
         putExtendedInfo()
         postUpdate()
+        cycleCount++
     }
 
     /**
@@ -281,5 +282,18 @@ public class PlayerInfoProtocol(
          */
         public const val PROTOCOL_CAPACITY: Int = 2048
         private val logger: InlineLogger = InlineLogger()
+
+        /**
+         * The number of Player info update cycles that have occurred.
+         * We need to track this to avoid a nasty bug with servers de-allocating + re-allocating
+         * an avatar on the same cycle, in a small area. The effective bug is that another player takes
+         * ones' avatar, which leads to info protocol thinking nothing has changed (assuming the new player
+         * is still within range of the old one, enough to be in high resolution).
+         *
+         * We solve this by forcibly removing a player from high resolution view if the avatar was
+         * allocated on current cycle. If the player is still within range, they will be re-added
+         * later on in the cycle via low resolution updates - but correctly this time around!
+         */
+        internal var cycleCount: Int = 0
     }
 }

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/util/ReferencePooledObject.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/util/ReferencePooledObject.kt
@@ -31,4 +31,14 @@ public interface ReferencePooledObject {
      * during the [onAlloc], to ensure no work is 'wasted'.
      */
     public fun onDealloc()
+
+    /**
+     * Whether this reference pooled object is destroyed.
+     * A destroyed object will not be returned back to the pool and instead will be left off for the
+     * garbage collector to clean up in due time. This condition is only hit when there was some error
+     * thrown during the processing of a given info object. In order to mitigate potential future
+     * problems that might continue to stem from re-using this object, we discard it altogether.
+     * @return whether the info object is destroyed and should not be returned to the pool.
+     */
+    public fun isDestroyed(): Boolean
 }

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityAvatar.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityAvatar.kt
@@ -52,6 +52,15 @@ public class WorldEntityAvatar(
     internal var highResolutionBuffer: ByteBuf? = null
 
     /**
+     * The [WorldEntityProtocol.cycleCount] when this avatar was allocated.
+     * We use this to determine whether to perform a re-synchronization of a worldentity,
+     * which can happen when a worldentity is deallocated and reallocated on the same cycle,
+     * which could result in other clients not seeing any change take place. While rare,
+     * this possibility exists, and it could result in some rather odd bugs.
+     */
+    internal var allocateCycle: Int = WorldEntityProtocol.cycleCount
+
+    /**
      * Precomputes the high resolution buffer of this world entity.
      */
     internal fun precompute() {

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityInfo.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityInfo.kt
@@ -277,7 +277,7 @@ public class WorldEntityInfo internal constructor(
         for (i in 0..<count) {
             val index = this.highResolutionIndices[i].toInt()
             val avatar = avatarRepository.getOrNull(index)
-            if (avatar == null || !inRange(avatar)) {
+            if (avatar == null || !inRange(avatar) || isReallocated(avatar)) {
                 highResolutionIndices[i] = INDEX_TERMINATOR
                 this.highResolutionIndicesCount--
                 this.removedWorldEntities += index
@@ -393,6 +393,13 @@ public class WorldEntityInfo internal constructor(
                         renderDistance,
                     )
             )
+    }
+
+    private fun isReallocated(avatar: WorldEntityAvatar): Boolean {
+        // If the avatar was allocated on this cycle, ensure we remove (and potentially re-add later)
+        // this avatar. This is due to a worldentity of the same index being deallocated and reallocated
+        // as a new instance in the same cycle.
+        return avatar.allocateCycle == WorldEntityProtocol.cycleCount
     }
 
     override fun onAlloc(

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityInfo.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityInfo.kt
@@ -82,9 +82,13 @@ public class WorldEntityInfo internal constructor(
     private val addedWorldEntities = ArrayList<Int>()
     private val removedWorldEntities = ArrayList<Int>()
     private var buffer: ByteBuf? = null
+
+    @Volatile
     internal var exception: Exception? = null
     private var builtIntoPacket: Boolean = false
     private var renderCoord: CoordGrid = CoordGrid.INVALID
+
+    override fun isDestroyed(): Boolean = this.exception != null
 
     /**
      * Updates the render distance for this player, potentially allowing

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityProtocol.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityProtocol.kt
@@ -63,6 +63,10 @@ public class WorldEntityProtocol(
      * @param info the world entity info to be deallocated.
      */
     public fun dealloc(info: WorldEntityInfo) {
+        // Prevent returning a destroyed worldentity info object back into the pool
+        if (info.isDestroyed()) {
+            return
+        }
         worldEntityInfoRepository.dealloc(info.localIndex)
     }
 

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityProtocol.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityProtocol.kt
@@ -77,6 +77,7 @@ public class WorldEntityProtocol(
         prepareHighResolutionBuffers()
         updateInfos()
         postUpdate()
+        cycleCount++
     }
 
     /**
@@ -115,7 +116,6 @@ public class WorldEntityProtocol(
             val avatar = avatarRepository.getOrNull(i) ?: continue
             avatar.postUpdate()
         }
-        avatarRepository.transferAvatars()
     }
 
     /**
@@ -169,5 +169,18 @@ public class WorldEntityProtocol(
          * The logger used to notify about exceptions that may otherwise be lost.
          */
         private val logger: InlineLogger = InlineLogger()
+
+        /**
+         * The number of Worldentity info update cycles that have occurred.
+         * We need to track this to avoid a nasty bug with servers de-allocating + re-allocating
+         * an avatar on the same cycle, in a small area. The effective bug is that another worldentity takes
+         * ones' avatar, which leads to info protocol thinking nothing has changed (assuming the new worldentity
+         * is still within range of the old one, enough to be in high resolution).
+         *
+         * We solve this by forcibly removing a worldentity from high resolution view if the avatar was
+         * allocated on current cycle. If the worldentity is still within range, they will be re-added
+         * later on in the cycle via low resolution updates - but correctly this time around!
+         */
+        internal var cycleCount: Int = 0
     }
 }

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfo.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfo.kt
@@ -58,6 +58,7 @@ public class NpcInfo internal constructor(
      * This exception will be propagated further during the [toNpcInfoPacket] function call,
      * allowing the server to handle it properly at a per-player basis.
      */
+    @Volatile
     internal var exception: Exception? = null
 
     /**
@@ -65,6 +66,8 @@ public class NpcInfo internal constructor(
      * The root world is placed at the end of this array, however id -1 will be treated as the root.
      */
     internal val details: Array<NpcInfoWorldDetails?> = arrayOfNulls(WORLD_ENTITY_CAPACITY + 1)
+
+    override fun isDestroyed(): Boolean = this.exception != null
 
     /**
      * Updates the build area of a given world to the specified one.

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfoProtocol.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfoProtocol.kt
@@ -78,6 +78,10 @@ public class NpcInfoProtocol(
      * @param info the npc info object to deallocate
      */
     public fun dealloc(info: NpcInfo) {
+        // Prevent returning a destroyed npc info object back into the pool
+        if (info.isDestroyed()) {
+            return
+        }
         npcInfoRepository.dealloc(info.localPlayerIndex)
     }
 

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerAvatar.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerAvatar.kt
@@ -80,8 +80,32 @@ public class PlayerAvatar internal constructor(
             huffmanCodec,
         )
 
+    /**
+     * Whether this avatar is completed hidden from everyone else. Note that this completely skips
+     * sending any information to the client about this given avatar, it is not the same as soft
+     * hiding via the appearance extended info.
+     */
     internal var hidden: Boolean = false
 
+    /**
+     * The [PlayerInfoProtocol.cycleCount] when this avatar was allocated.
+     * We use this to determine whether to perform a re-synchronization of a player,
+     * which can happen when a player is deallocated and reallocated on the same cycle,
+     * which could result in other players not seeing any change take place. While rare,
+     * this possibility exists, and it could result in some rather odd bugs.
+     */
+    internal var allocateCycle: Int = PlayerInfoProtocol.cycleCount
+
+    /**
+     * Sets the avatar as hidden (or unhidden, depending on [hidden]). When hidden via this function,
+     * no information is transmitted to the clients about this avatar. It is a hard-hiding function,
+     * unlike the one via appearance extended info, which strictly only hides client-side, but all
+     * clients still receive information about the client existing.
+     * The benefit to this function is that no plugins or RuneLite implementations can snoop on other
+     * players that are meant to be hidden. The downside, however, is that because the client has no
+     * knowledge of that specific avatar whatsoever, un-hiding while the player is moving is not as
+     * smooth as with the appearance variant, since it first appears as if the player teleported in.
+     */
     public fun setHidden(hidden: Boolean) {
         this.hidden = hidden
     }

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
@@ -685,6 +685,12 @@ public class PlayerInfo internal constructor(
         if (other.avatar.hidden) {
             return false
         }
+        // If the avatar was allocated on this cycle, ensure we remove (and potentially re-add later)
+        // this avatar. This is due to someone logging out and another player taking the avatar the same
+        // cycle - which would otherwise potentially go by unnoticed, with the client assuming nothing changed.
+        if (other.avatar.allocateCycle == PlayerInfoProtocol.cycleCount) {
+            return false
+        }
         val coord = other.avatar.currentCoord
         if (!details.renderCoord.inDistance(coord, this.avatar.resizeRange)) {
             return false
@@ -801,6 +807,7 @@ public class PlayerInfo internal constructor(
         avatar.extendedInfo.localIndex = index
         this.oldSchoolClientType = oldSchoolClientType
         avatar.reset()
+        this.avatar.allocateCycle = PlayerInfoProtocol.cycleCount
         this.activeWorldId = ROOT_WORLD
         // There is always a root world!
         val rootDetails = protocol.detailsStorage.poll(ROOT_WORLD)

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
@@ -83,6 +83,7 @@ public class PlayerInfo internal constructor(
      * This exception will be propagated further during the [toPacket] function call,
      * allowing the server to handle it properly at a per-player basis.
      */
+    @Volatile
     internal var exception: Exception? = null
 
     /**
@@ -106,6 +107,8 @@ public class PlayerInfo internal constructor(
      * world basis.
      */
     private var invalidateAppearanceCache: Boolean = false
+
+    override fun isDestroyed(): Boolean = this.exception != null
 
     /**
      * Checks if appearance needs invalidation, and invalidates if so.

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfoProtocol.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfoProtocol.kt
@@ -107,6 +107,10 @@ public class PlayerInfoProtocol(
      * @param info the player info object
      */
     public fun dealloc(info: PlayerInfo) {
+        // Prevent returning a destroyed player info object back into the pool
+        if (info.isDestroyed()) {
+            return
+        }
         playerInfoRepository.dealloc(info.localIndex)
     }
 

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfoProtocol.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfoProtocol.kt
@@ -128,6 +128,7 @@ public class PlayerInfoProtocol(
         prepareExtendedInfo()
         putExtendedInfo()
         postUpdate()
+        cycleCount++
     }
 
     /**
@@ -281,5 +282,18 @@ public class PlayerInfoProtocol(
          */
         public const val PROTOCOL_CAPACITY: Int = 2048
         private val logger: InlineLogger = InlineLogger()
+
+        /**
+         * The number of Player info update cycles that have occurred.
+         * We need to track this to avoid a nasty bug with servers de-allocating + re-allocating
+         * an avatar on the same cycle, in a small area. The effective bug is that another player takes
+         * ones' avatar, which leads to info protocol thinking nothing has changed (assuming the new player
+         * is still within range of the old one, enough to be in high resolution).
+         *
+         * We solve this by forcibly removing a player from high resolution view if the avatar was
+         * allocated on current cycle. If the player is still within range, they will be re-added
+         * later on in the cycle via low resolution updates - but correctly this time around!
+         */
+        internal var cycleCount: Int = 0
     }
 }

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/util/ReferencePooledObject.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/util/ReferencePooledObject.kt
@@ -31,4 +31,14 @@ public interface ReferencePooledObject {
      * during the [onAlloc], to ensure no work is 'wasted'.
      */
     public fun onDealloc()
+
+    /**
+     * Whether this reference pooled object is destroyed.
+     * A destroyed object will not be returned back to the pool and instead will be left off for the
+     * garbage collector to clean up in due time. This condition is only hit when there was some error
+     * thrown during the processing of a given info object. In order to mitigate potential future
+     * problems that might continue to stem from re-using this object, we discard it altogether.
+     * @return whether the info object is destroyed and should not be returned to the pool.
+     */
+    public fun isDestroyed(): Boolean
 }

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityAvatar.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityAvatar.kt
@@ -52,6 +52,15 @@ public class WorldEntityAvatar(
     internal var highResolutionBuffer: ByteBuf? = null
 
     /**
+     * The [WorldEntityProtocol.cycleCount] when this avatar was allocated.
+     * We use this to determine whether to perform a re-synchronization of a worldentity,
+     * which can happen when a worldentity is deallocated and reallocated on the same cycle,
+     * which could result in other clients not seeing any change take place. While rare,
+     * this possibility exists, and it could result in some rather odd bugs.
+     */
+    internal var allocateCycle: Int = WorldEntityProtocol.cycleCount
+
+    /**
      * Precomputes the high resolution buffer of this world entity.
      */
     internal fun precompute() {

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityInfo.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityInfo.kt
@@ -277,7 +277,7 @@ public class WorldEntityInfo internal constructor(
         for (i in 0..<count) {
             val index = this.highResolutionIndices[i].toInt()
             val avatar = avatarRepository.getOrNull(index)
-            if (avatar == null || !inRange(avatar)) {
+            if (avatar == null || !inRange(avatar) || isReallocated(avatar)) {
                 highResolutionIndices[i] = INDEX_TERMINATOR
                 this.highResolutionIndicesCount--
                 this.removedWorldEntities += index
@@ -393,6 +393,13 @@ public class WorldEntityInfo internal constructor(
                         renderDistance,
                     )
             )
+    }
+
+    private fun isReallocated(avatar: WorldEntityAvatar): Boolean {
+        // If the avatar was allocated on this cycle, ensure we remove (and potentially re-add later)
+        // this avatar. This is due to a worldentity of the same index being deallocated and reallocated
+        // as a new instance in the same cycle.
+        return avatar.allocateCycle == WorldEntityProtocol.cycleCount
     }
 
     override fun onAlloc(

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityInfo.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityInfo.kt
@@ -82,9 +82,13 @@ public class WorldEntityInfo internal constructor(
     private val addedWorldEntities = ArrayList<Int>()
     private val removedWorldEntities = ArrayList<Int>()
     private var buffer: ByteBuf? = null
+
+    @Volatile
     internal var exception: Exception? = null
     private var builtIntoPacket: Boolean = false
     private var renderCoord: CoordGrid = CoordGrid.INVALID
+
+    override fun isDestroyed(): Boolean = this.exception != null
 
     /**
      * Updates the render distance for this player, potentially allowing

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityProtocol.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityProtocol.kt
@@ -63,6 +63,10 @@ public class WorldEntityProtocol(
      * @param info the world entity info to be deallocated.
      */
     public fun dealloc(info: WorldEntityInfo) {
+        // Prevent returning a destroyed worldentity info object back into the pool
+        if (info.isDestroyed()) {
+            return
+        }
         worldEntityInfoRepository.dealloc(info.localIndex)
     }
 

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityProtocol.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityProtocol.kt
@@ -77,6 +77,7 @@ public class WorldEntityProtocol(
         prepareHighResolutionBuffers()
         updateInfos()
         postUpdate()
+        cycleCount++
     }
 
     /**
@@ -115,7 +116,6 @@ public class WorldEntityProtocol(
             val avatar = avatarRepository.getOrNull(i) ?: continue
             avatar.postUpdate()
         }
-        avatarRepository.transferAvatars()
     }
 
     /**
@@ -169,5 +169,18 @@ public class WorldEntityProtocol(
          * The logger used to notify about exceptions that may otherwise be lost.
          */
         private val logger: InlineLogger = InlineLogger()
+
+        /**
+         * The number of Worldentity info update cycles that have occurred.
+         * We need to track this to avoid a nasty bug with servers de-allocating + re-allocating
+         * an avatar on the same cycle, in a small area. The effective bug is that another worldentity takes
+         * ones' avatar, which leads to info protocol thinking nothing has changed (assuming the new worldentity
+         * is still within range of the old one, enough to be in high resolution).
+         *
+         * We solve this by forcibly removing a worldentity from high resolution view if the avatar was
+         * allocated on current cycle. If the worldentity is still within range, they will be re-added
+         * later on in the cycle via low resolution updates - but correctly this time around!
+         */
+        internal var cycleCount: Int = 0
     }
 }

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfo.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfo.kt
@@ -58,6 +58,7 @@ public class NpcInfo internal constructor(
      * This exception will be propagated further during the [toNpcInfoPacket] function call,
      * allowing the server to handle it properly at a per-player basis.
      */
+    @Volatile
     internal var exception: Exception? = null
 
     /**
@@ -65,6 +66,8 @@ public class NpcInfo internal constructor(
      * The root world is placed at the end of this array, however id -1 will be treated as the root.
      */
     internal val details: Array<NpcInfoWorldDetails?> = arrayOfNulls(WORLD_ENTITY_CAPACITY + 1)
+
+    override fun isDestroyed(): Boolean = this.exception != null
 
     /**
      * Updates the build area of a given world to the specified one.

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfoProtocol.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfoProtocol.kt
@@ -78,6 +78,10 @@ public class NpcInfoProtocol(
      * @param info the npc info object to deallocate
      */
     public fun dealloc(info: NpcInfo) {
+        // Prevent returning a destroyed npc info object back into the pool
+        if (info.isDestroyed()) {
+            return
+        }
         npcInfoRepository.dealloc(info.localPlayerIndex)
     }
 

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerAvatar.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerAvatar.kt
@@ -80,8 +80,32 @@ public class PlayerAvatar internal constructor(
             huffmanCodec,
         )
 
+    /**
+     * Whether this avatar is completed hidden from everyone else. Note that this completely skips
+     * sending any information to the client about this given avatar, it is not the same as soft
+     * hiding via the appearance extended info.
+     */
     internal var hidden: Boolean = false
 
+    /**
+     * The [PlayerInfoProtocol.cycleCount] when this avatar was allocated.
+     * We use this to determine whether to perform a re-synchronization of a player,
+     * which can happen when a player is deallocated and reallocated on the same cycle,
+     * which could result in other players not seeing any change take place. While rare,
+     * this possibility exists, and it could result in some rather odd bugs.
+     */
+    internal var allocateCycle: Int = PlayerInfoProtocol.cycleCount
+
+    /**
+     * Sets the avatar as hidden (or unhidden, depending on [hidden]). When hidden via this function,
+     * no information is transmitted to the clients about this avatar. It is a hard-hiding function,
+     * unlike the one via appearance extended info, which strictly only hides client-side, but all
+     * clients still receive information about the client existing.
+     * The benefit to this function is that no plugins or RuneLite implementations can snoop on other
+     * players that are meant to be hidden. The downside, however, is that because the client has no
+     * knowledge of that specific avatar whatsoever, un-hiding while the player is moving is not as
+     * smooth as with the appearance variant, since it first appears as if the player teleported in.
+     */
     public fun setHidden(hidden: Boolean) {
         this.hidden = hidden
     }

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
@@ -685,6 +685,12 @@ public class PlayerInfo internal constructor(
         if (other.avatar.hidden) {
             return false
         }
+        // If the avatar was allocated on this cycle, ensure we remove (and potentially re-add later)
+        // this avatar. This is due to someone logging out and another player taking the avatar the same
+        // cycle - which would otherwise potentially go by unnoticed, with the client assuming nothing changed.
+        if (other.avatar.allocateCycle == PlayerInfoProtocol.cycleCount) {
+            return false
+        }
         val coord = other.avatar.currentCoord
         if (!details.renderCoord.inDistance(coord, this.avatar.resizeRange)) {
             return false
@@ -800,13 +806,14 @@ public class PlayerInfo internal constructor(
         this.localIndex = index
         avatar.extendedInfo.localIndex = index
         this.oldSchoolClientType = oldSchoolClientType
+        avatar.reset()
+        this.avatar.allocateCycle = PlayerInfoProtocol.cycleCount
         this.activeWorldId = ROOT_WORLD
         // There is always a root world!
         val rootDetails = protocol.detailsStorage.poll(ROOT_WORLD)
         details[PROTOCOL_CAPACITY] = rootDetails
 
         if (newInstance) return
-        avatar.reset()
         rootDetails.lowResolutionIndices.fill(0)
         rootDetails.lowResolutionCount = 0
         rootDetails.highResolutionIndices.fill(0)

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
@@ -83,6 +83,7 @@ public class PlayerInfo internal constructor(
      * This exception will be propagated further during the [toPacket] function call,
      * allowing the server to handle it properly at a per-player basis.
      */
+    @Volatile
     internal var exception: Exception? = null
 
     /**
@@ -106,6 +107,8 @@ public class PlayerInfo internal constructor(
      * world basis.
      */
     private var invalidateAppearanceCache: Boolean = false
+
+    override fun isDestroyed(): Boolean = this.exception != null
 
     /**
      * Checks if appearance needs invalidation, and invalidates if so.

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfoProtocol.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfoProtocol.kt
@@ -107,6 +107,10 @@ public class PlayerInfoProtocol(
      * @param info the player info object
      */
     public fun dealloc(info: PlayerInfo) {
+        // Prevent returning a destroyed player info object back into the pool
+        if (info.isDestroyed()) {
+            return
+        }
         playerInfoRepository.dealloc(info.localIndex)
     }
 

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfoProtocol.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfoProtocol.kt
@@ -128,6 +128,7 @@ public class PlayerInfoProtocol(
         prepareExtendedInfo()
         putExtendedInfo()
         postUpdate()
+        cycleCount++
     }
 
     /**
@@ -281,5 +282,18 @@ public class PlayerInfoProtocol(
          */
         public const val PROTOCOL_CAPACITY: Int = 2048
         private val logger: InlineLogger = InlineLogger()
+
+        /**
+         * The number of Player info update cycles that have occurred.
+         * We need to track this to avoid a nasty bug with servers de-allocating + re-allocating
+         * an avatar on the same cycle, in a small area. The effective bug is that another player takes
+         * ones' avatar, which leads to info protocol thinking nothing has changed (assuming the new player
+         * is still within range of the old one, enough to be in high resolution).
+         *
+         * We solve this by forcibly removing a player from high resolution view if the avatar was
+         * allocated on current cycle. If the player is still within range, they will be re-added
+         * later on in the cycle via low resolution updates - but correctly this time around!
+         */
+        internal var cycleCount: Int = 0
     }
 }

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/util/ReferencePooledObject.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/util/ReferencePooledObject.kt
@@ -31,4 +31,14 @@ public interface ReferencePooledObject {
      * during the [onAlloc], to ensure no work is 'wasted'.
      */
     public fun onDealloc()
+
+    /**
+     * Whether this reference pooled object is destroyed.
+     * A destroyed object will not be returned back to the pool and instead will be left off for the
+     * garbage collector to clean up in due time. This condition is only hit when there was some error
+     * thrown during the processing of a given info object. In order to mitigate potential future
+     * problems that might continue to stem from re-using this object, we discard it altogether.
+     * @return whether the info object is destroyed and should not be returned to the pool.
+     */
+    public fun isDestroyed(): Boolean
 }

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityAvatar.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityAvatar.kt
@@ -52,6 +52,15 @@ public class WorldEntityAvatar(
     internal var highResolutionBuffer: ByteBuf? = null
 
     /**
+     * The [WorldEntityProtocol.cycleCount] when this avatar was allocated.
+     * We use this to determine whether to perform a re-synchronization of a worldentity,
+     * which can happen when a worldentity is deallocated and reallocated on the same cycle,
+     * which could result in other clients not seeing any change take place. While rare,
+     * this possibility exists, and it could result in some rather odd bugs.
+     */
+    internal var allocateCycle: Int = WorldEntityProtocol.cycleCount
+
+    /**
      * Precomputes the high resolution buffer of this world entity.
      */
     internal fun precompute() {

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityInfo.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityInfo.kt
@@ -277,7 +277,7 @@ public class WorldEntityInfo internal constructor(
         for (i in 0..<count) {
             val index = this.highResolutionIndices[i].toInt()
             val avatar = avatarRepository.getOrNull(index)
-            if (avatar == null || !inRange(avatar)) {
+            if (avatar == null || !inRange(avatar) || isReallocated(avatar)) {
                 highResolutionIndices[i] = INDEX_TERMINATOR
                 this.highResolutionIndicesCount--
                 this.removedWorldEntities += index
@@ -393,6 +393,13 @@ public class WorldEntityInfo internal constructor(
                         renderDistance,
                     )
             )
+    }
+
+    private fun isReallocated(avatar: WorldEntityAvatar): Boolean {
+        // If the avatar was allocated on this cycle, ensure we remove (and potentially re-add later)
+        // this avatar. This is due to a worldentity of the same index being deallocated and reallocated
+        // as a new instance in the same cycle.
+        return avatar.allocateCycle == WorldEntityProtocol.cycleCount
     }
 
     override fun onAlloc(

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityInfo.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityInfo.kt
@@ -82,9 +82,13 @@ public class WorldEntityInfo internal constructor(
     private val addedWorldEntities = ArrayList<Int>()
     private val removedWorldEntities = ArrayList<Int>()
     private var buffer: ByteBuf? = null
+
+    @Volatile
     internal var exception: Exception? = null
     private var builtIntoPacket: Boolean = false
     private var renderCoord: CoordGrid = CoordGrid.INVALID
+
+    override fun isDestroyed(): Boolean = this.exception != null
 
     /**
      * Updates the render distance for this player, potentially allowing

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityProtocol.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityProtocol.kt
@@ -63,6 +63,10 @@ public class WorldEntityProtocol(
      * @param info the world entity info to be deallocated.
      */
     public fun dealloc(info: WorldEntityInfo) {
+        // Prevent returning a destroyed worldentity info object back into the pool
+        if (info.isDestroyed()) {
+            return
+        }
         worldEntityInfoRepository.dealloc(info.localIndex)
     }
 

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityProtocol.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityProtocol.kt
@@ -77,6 +77,7 @@ public class WorldEntityProtocol(
         prepareHighResolutionBuffers()
         updateInfos()
         postUpdate()
+        cycleCount++
     }
 
     /**
@@ -115,7 +116,6 @@ public class WorldEntityProtocol(
             val avatar = avatarRepository.getOrNull(i) ?: continue
             avatar.postUpdate()
         }
-        avatarRepository.transferAvatars()
     }
 
     /**
@@ -169,5 +169,18 @@ public class WorldEntityProtocol(
          * The logger used to notify about exceptions that may otherwise be lost.
          */
         private val logger: InlineLogger = InlineLogger()
+
+        /**
+         * The number of Worldentity info update cycles that have occurred.
+         * We need to track this to avoid a nasty bug with servers de-allocating + re-allocating
+         * an avatar on the same cycle, in a small area. The effective bug is that another worldentity takes
+         * ones' avatar, which leads to info protocol thinking nothing has changed (assuming the new worldentity
+         * is still within range of the old one, enough to be in high resolution).
+         *
+         * We solve this by forcibly removing a worldentity from high resolution view if the avatar was
+         * allocated on current cycle. If the worldentity is still within range, they will be re-added
+         * later on in the cycle via low resolution updates - but correctly this time around!
+         */
+        internal var cycleCount: Int = 0
     }
 }

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfo.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfo.kt
@@ -58,6 +58,7 @@ public class NpcInfo internal constructor(
      * This exception will be propagated further during the [toNpcInfoPacket] function call,
      * allowing the server to handle it properly at a per-player basis.
      */
+    @Volatile
     internal var exception: Exception? = null
 
     /**
@@ -65,6 +66,8 @@ public class NpcInfo internal constructor(
      * The root world is placed at the end of this array, however id -1 will be treated as the root.
      */
     internal val details: Array<NpcInfoWorldDetails?> = arrayOfNulls(WORLD_ENTITY_CAPACITY + 1)
+
+    override fun isDestroyed(): Boolean = this.exception != null
 
     /**
      * Updates the build area of a given world to the specified one.

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfoProtocol.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfoProtocol.kt
@@ -78,6 +78,10 @@ public class NpcInfoProtocol(
      * @param info the npc info object to deallocate
      */
     public fun dealloc(info: NpcInfo) {
+        // Prevent returning a destroyed npc info object back into the pool
+        if (info.isDestroyed()) {
+            return
+        }
         npcInfoRepository.dealloc(info.localPlayerIndex)
     }
 

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerAvatar.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerAvatar.kt
@@ -87,8 +87,32 @@ public class PlayerAvatar internal constructor(
             huffmanCodec,
         )
 
+    /**
+     * Whether this avatar is completed hidden from everyone else. Note that this completely skips
+     * sending any information to the client about this given avatar, it is not the same as soft
+     * hiding via the appearance extended info.
+     */
     internal var hidden: Boolean = false
 
+    /**
+     * The [PlayerInfoProtocol.cycleCount] when this avatar was allocated.
+     * We use this to determine whether to perform a re-synchronization of a player,
+     * which can happen when a player is deallocated and reallocated on the same cycle,
+     * which could result in other players not seeing any change take place. While rare,
+     * this possibility exists, and it could result in some rather odd bugs.
+     */
+    internal var allocateCycle: Int = PlayerInfoProtocol.cycleCount
+
+    /**
+     * Sets the avatar as hidden (or unhidden, depending on [hidden]). When hidden via this function,
+     * no information is transmitted to the clients about this avatar. It is a hard-hiding function,
+     * unlike the one via appearance extended info, which strictly only hides client-side, but all
+     * clients still receive information about the client existing.
+     * The benefit to this function is that no plugins or RuneLite implementations can snoop on other
+     * players that are meant to be hidden. The downside, however, is that because the client has no
+     * knowledge of that specific avatar whatsoever, un-hiding while the player is moving is not as
+     * smooth as with the appearance variant, since it first appears as if the player teleported in.
+     */
     public fun setHidden(hidden: Boolean) {
         this.hidden = hidden
     }

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
@@ -150,6 +150,7 @@ public class PlayerInfo internal constructor(
      * This exception will be propagated further during the [toPacket] function call,
      * allowing the server to handle it properly at a per-player basis.
      */
+    @Volatile
     internal var exception: Exception? = null
 
     /**
@@ -173,6 +174,8 @@ public class PlayerInfo internal constructor(
      */
     @Throws(IllegalStateException::class)
     public fun backingBuffer(): ByteBuf = checkNotNull(buffer)
+
+    override fun isDestroyed(): Boolean = this.exception != null
 
     /**
      * Updates the render coordinate for the provided world id.

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
@@ -707,6 +707,12 @@ public class PlayerInfo internal constructor(
         if (other.avatar.hidden) {
             return false
         }
+        // If the avatar was allocated on this cycle, ensure we remove (and potentially re-add later)
+        // this avatar. This is due to someone logging out and another player taking the avatar the same
+        // cycle - which would otherwise potentially go by unnoticed, with the client assuming nothing changed.
+        if (other.avatar.allocateCycle == PlayerInfoProtocol.cycleCount) {
+            return false
+        }
         val worldId = other.avatar.worldId
         val details = getDetailsOrNull(worldId) ?: return false
         val coord = other.avatar.currentCoord
@@ -809,6 +815,7 @@ public class PlayerInfo internal constructor(
         avatar.extendedInfo.localIndex = index
         this.oldSchoolClientType = oldSchoolClientType
         avatar.reset()
+        this.avatar.allocateCycle = PlayerInfoProtocol.cycleCount
         lowResolutionIndices.fill(0)
         lowResolutionCount = 0
         highResolutionIndices.fill(0)

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfoProtocol.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfoProtocol.kt
@@ -122,6 +122,7 @@ public class PlayerInfoProtocol(
         prepareExtendedInfo()
         putExtendedInfo()
         postUpdate()
+        cycleCount++
     }
 
     /**
@@ -258,5 +259,18 @@ public class PlayerInfoProtocol(
          */
         public const val PROTOCOL_CAPACITY: Int = 2048
         private val logger: InlineLogger = InlineLogger()
+
+        /**
+         * The number of Player info update cycles that have occurred.
+         * We need to track this to avoid a nasty bug with servers de-allocating + re-allocating
+         * an avatar on the same cycle, in a small area. The effective bug is that another player takes
+         * ones' avatar, which leads to info protocol thinking nothing has changed (assuming the new player
+         * is still within range of the old one, enough to be in high resolution).
+         *
+         * We solve this by forcibly removing a player from high resolution view if the avatar was
+         * allocated on current cycle. If the player is still within range, they will be re-added
+         * later on in the cycle via low resolution updates - but correctly this time around!
+         */
+        internal var cycleCount: Int = 0
     }
 }

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfoProtocol.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfoProtocol.kt
@@ -101,6 +101,10 @@ public class PlayerInfoProtocol(
      * @param info the player info object
      */
     public fun dealloc(info: PlayerInfo) {
+        // Prevent returning a destroyed player info object back into the pool
+        if (info.isDestroyed()) {
+            return
+        }
         playerInfoRepository.dealloc(info.localIndex)
     }
 

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/util/ReferencePooledObject.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/util/ReferencePooledObject.kt
@@ -31,4 +31,14 @@ public interface ReferencePooledObject {
      * during the [onAlloc], to ensure no work is 'wasted'.
      */
     public fun onDealloc()
+
+    /**
+     * Whether this reference pooled object is destroyed.
+     * A destroyed object will not be returned back to the pool and instead will be left off for the
+     * garbage collector to clean up in due time. This condition is only hit when there was some error
+     * thrown during the processing of a given info object. In order to mitigate potential future
+     * problems that might continue to stem from re-using this object, we discard it altogether.
+     * @return whether the info object is destroyed and should not be returned to the pool.
+     */
+    public fun isDestroyed(): Boolean
 }

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityAvatar.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityAvatar.kt
@@ -52,6 +52,15 @@ public class WorldEntityAvatar(
     internal var highResolutionBuffer: ByteBuf? = null
 
     /**
+     * The [WorldEntityProtocol.cycleCount] when this avatar was allocated.
+     * We use this to determine whether to perform a re-synchronization of a worldentity,
+     * which can happen when a worldentity is deallocated and reallocated on the same cycle,
+     * which could result in other clients not seeing any change take place. While rare,
+     * this possibility exists, and it could result in some rather odd bugs.
+     */
+    internal var allocateCycle: Int = WorldEntityProtocol.cycleCount
+
+    /**
      * Precomputes the high resolution buffer of this world entity.
      */
     internal fun precompute() {

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityInfo.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityInfo.kt
@@ -277,7 +277,7 @@ public class WorldEntityInfo internal constructor(
         for (i in 0..<count) {
             val index = this.highResolutionIndices[i].toInt()
             val avatar = avatarRepository.getOrNull(index)
-            if (avatar == null || !inRange(avatar)) {
+            if (avatar == null || !inRange(avatar) || isReallocated(avatar)) {
                 highResolutionIndices[i] = INDEX_TERMINATOR
                 this.highResolutionIndicesCount--
                 this.removedWorldEntities += index
@@ -393,6 +393,13 @@ public class WorldEntityInfo internal constructor(
                         renderDistance,
                     )
             )
+    }
+
+    private fun isReallocated(avatar: WorldEntityAvatar): Boolean {
+        // If the avatar was allocated on this cycle, ensure we remove (and potentially re-add later)
+        // this avatar. This is due to a worldentity of the same index being deallocated and reallocated
+        // as a new instance in the same cycle.
+        return avatar.allocateCycle == WorldEntityProtocol.cycleCount
     }
 
     override fun onAlloc(

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityInfo.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityInfo.kt
@@ -82,9 +82,13 @@ public class WorldEntityInfo internal constructor(
     private val addedWorldEntities = ArrayList<Int>()
     private val removedWorldEntities = ArrayList<Int>()
     private var buffer: ByteBuf? = null
+
+    @Volatile
     internal var exception: Exception? = null
     private var builtIntoPacket: Boolean = false
     private var renderCoord: CoordGrid = CoordGrid.INVALID
+
+    override fun isDestroyed(): Boolean = this.exception != null
 
     /**
      * Updates the render distance for this player, potentially allowing

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityProtocol.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityProtocol.kt
@@ -63,6 +63,10 @@ public class WorldEntityProtocol(
      * @param info the world entity info to be deallocated.
      */
     public fun dealloc(info: WorldEntityInfo) {
+        // Prevent returning a destroyed worldentity info object back into the pool
+        if (info.isDestroyed()) {
+            return
+        }
         worldEntityInfoRepository.dealloc(info.localIndex)
     }
 

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityProtocol.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityProtocol.kt
@@ -77,6 +77,7 @@ public class WorldEntityProtocol(
         prepareHighResolutionBuffers()
         updateInfos()
         postUpdate()
+        cycleCount++
     }
 
     /**
@@ -115,7 +116,6 @@ public class WorldEntityProtocol(
             val avatar = avatarRepository.getOrNull(i) ?: continue
             avatar.postUpdate()
         }
-        avatarRepository.transferAvatars()
     }
 
     /**
@@ -169,5 +169,18 @@ public class WorldEntityProtocol(
          * The logger used to notify about exceptions that may otherwise be lost.
          */
         private val logger: InlineLogger = InlineLogger()
+
+        /**
+         * The number of Worldentity info update cycles that have occurred.
+         * We need to track this to avoid a nasty bug with servers de-allocating + re-allocating
+         * an avatar on the same cycle, in a small area. The effective bug is that another worldentity takes
+         * ones' avatar, which leads to info protocol thinking nothing has changed (assuming the new worldentity
+         * is still within range of the old one, enough to be in high resolution).
+         *
+         * We solve this by forcibly removing a worldentity from high resolution view if the avatar was
+         * allocated on current cycle. If the worldentity is still within range, they will be re-added
+         * later on in the cycle via low resolution updates - but correctly this time around!
+         */
+        internal var cycleCount: Int = 0
     }
 }


### PR DESCRIPTION
Fixes potential issues where servers might deallocate and reallocate the same index player or worldentity info on the same game cycle. This would result in any players previously observing it not acknowledging that the entity underneath an avatar was completely swapped out, and could result in visual artefacting. This is typically only possible if servers do not use the round-robin index allocation system, but it is _technically_ also possible to happen even with it, although in practice never should.