### PR TITLE
Java Value Class Compatibility

### DIFF
--- a/protocol/osrs-221/osrs-221-common/src/main/kotlin/net/rsprot/protocol/common/game/outgoing/inv/InventoryObject.kt
+++ b/protocol/osrs-221/osrs-221-common/src/main/kotlin/net/rsprot/protocol/common/game/outgoing/inv/InventoryObject.kt
@@ -1,63 +1,50 @@
 package net.rsprot.protocol.common.game.outgoing.inv
 
 /**
- * Inventory objects are a value class around the primitive 'long'
- * to efficiently compress an inventory's contents into a long array.
- * This allows us to avoid any garbage creation that would otherwise
- * be created by making lists of objs repeatedly.
+ * Inventory object is a helper object built around the primitive 'long' type.
+ * We utilize longs directly here to reduce the effects of garbage creation
+ * via inventories, as this can otherwise get quite severe with a lot of players.
  */
-@JvmInline
-public value class InventoryObject(
-    public val packed: Long,
-) {
-    public constructor(
+public object InventoryObject {
+    public const val NULL: Long = -1
+
+    @JvmSynthetic
+    public operator fun invoke(
         slot: Int,
         id: Int,
         count: Int,
-    ) : this(
-        (slot.toLong() and 0xFFFF)
-            .or((id.toLong() and 0xFFFF) shl 16)
-            .or((count.toLong() and 0xFFFFFFFF) shl 32),
-    )
+    ): Long = pack(slot, id, count)
 
-    public constructor(
+    @JvmStatic
+    public fun pack(
+        slot: Int,
         id: Int,
         count: Int,
-    ) : this(
-        0,
-        id,
-        count,
-    )
+    ): Long =
+        (slot.toLong() and 0xFFFF)
+            .or((id.toLong() and 0xFFFF) shl 16)
+            .or((count.toLong() and 0xFFFFFFFF) shl 32)
 
-    public val slot: Int
-        get() {
-            val value = (packed and 0xFFFF).toInt()
-            return if (value == 0xFFFF) {
-                -1
-            } else {
-                value
-            }
+    @JvmStatic
+    public fun getSlot(packed: Long): Int {
+        val value = (packed and 0xFFFF).toInt()
+        return if (value == 0xFFFF) {
+            -1
+        } else {
+            value
         }
-    public val id: Int
-        get() {
-            val value = (packed ushr 16 and 0xFFFF).toInt()
-            return if (value == 0xFFFF) {
-                -1
-            } else {
-                value
-            }
-        }
-    public val count: Int
-        get() = (packed ushr 32).toInt()
-
-    override fun toString(): String =
-        "InventoryObject(" +
-            "slot=$slot, " +
-            "id=$id, " +
-            "count=$count" +
-            ")"
-
-    public companion object {
-        public val NULL: InventoryObject = InventoryObject(-1)
     }
+
+    @JvmStatic
+    public fun getId(packed: Long): Int {
+        val value = (packed ushr 16 and 0xFFFF).toInt()
+        return if (value == 0xFFFF) {
+            -1
+        } else {
+            value
+        }
+    }
+
+    @JvmStatic
+    public fun getCount(packed: Long): Int = (packed ushr 32).toInt()
 }

--- a/protocol/osrs-221/osrs-221-desktop/src/main/kotlin/net/rsprot/protocol/game/incoming/codec/events/EventMouseMoveDecoder.kt
+++ b/protocol/osrs-221/osrs-221-desktop/src/main/kotlin/net/rsprot/protocol/game/incoming/codec/events/EventMouseMoveDecoder.kt
@@ -48,12 +48,12 @@ public class EventMouseMoveDecoder : MessageDecoder<EventMouseMove> {
                 deltaY = (packed and 0x3F) - 32
             }
             val change =
-                EventMouseMove.MouseMovements.MousePosChange(
+                EventMouseMove.MouseMovements.MousePosChange.pack(
                     timeSinceLastMovement,
                     deltaX,
                     deltaY,
                 )
-            array[count++] = change.packed
+            array[count++] = change
         }
         val slice = array.copyOf(count)
         return EventMouseMove(

--- a/protocol/osrs-221/osrs-221-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/inv/UpdateInvFullEncoder.kt
+++ b/protocol/osrs-221/osrs-221-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/inv/UpdateInvFullEncoder.kt
@@ -27,12 +27,12 @@ public class UpdateInvFullEncoder : MessageEncoder<UpdateInvFull> {
                 buffer.p2Alt3(0)
                 continue
             }
-            val count = obj.count
+            val count = InventoryObject.getCount(obj)
             buffer.p1Alt1(count.coerceAtMost(0xFF))
             if (count >= 255) {
                 buffer.p4Alt2(count)
             }
-            buffer.p2Alt3(obj.id + 1)
+            buffer.p2Alt3(InventoryObject.getId(obj) + 1)
         }
         message.returnInventory()
     }

--- a/protocol/osrs-221/osrs-221-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/inv/UpdateInvPartialEncoder.kt
+++ b/protocol/osrs-221/osrs-221-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/inv/UpdateInvPartialEncoder.kt
@@ -3,6 +3,7 @@ package net.rsprot.protocol.game.outgoing.codec.inv
 import net.rsprot.buffer.JagByteBuf
 import net.rsprot.crypto.cipher.StreamCipher
 import net.rsprot.protocol.ServerProt
+import net.rsprot.protocol.common.game.outgoing.inv.InventoryObject
 import net.rsprot.protocol.game.outgoing.inv.UpdateInvPartial
 import net.rsprot.protocol.game.outgoing.prot.GameServerProt
 import net.rsprot.protocol.message.codec.MessageEncoder
@@ -21,14 +22,14 @@ public class UpdateInvPartialEncoder : MessageEncoder<UpdateInvPartial> {
         buffer.p2(message.inventoryId)
         for (i in 0..<message.count) {
             val obj = message.getObject(i)
-            buffer.pSmart1or2(obj.slot)
-            val id = obj.id
+            buffer.pSmart1or2(InventoryObject.getSlot(obj))
+            val id = InventoryObject.getId(obj)
             if (id == -1) {
                 buffer.p2(0)
                 continue
             }
             buffer.p2(id + 1)
-            val count = obj.count
+            val count = InventoryObject.getCount(obj)
             buffer.p1(count.coerceAtMost(0xFF))
             if (count >= 0xFF) {
                 buffer.p4(count)

--- a/protocol/osrs-221/osrs-221-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/LocAddChangeEncoder.kt
+++ b/protocol/osrs-221/osrs-221-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/LocAddChangeEncoder.kt
@@ -19,6 +19,6 @@ public class LocAddChangeEncoder : ZoneProtEncoder<LocAddChange> {
         buffer.p2Alt2(message.id)
         buffer.p1Alt1(message.coordInZonePacked)
         buffer.p1Alt3(message.locPropertiesPacked)
-        buffer.p1Alt3(message.opFlags.value)
+        buffer.p1Alt3(message.opFlags.toInt())
     }
 }

--- a/protocol/osrs-221/osrs-221-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/ObjAddEncoder.kt
+++ b/protocol/osrs-221/osrs-221-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/ObjAddEncoder.kt
@@ -22,7 +22,7 @@ public class ObjAddEncoder : ZoneProtEncoder<ObjAdd> {
         buffer.p2Alt1(message.id)
         buffer.p2Alt2(message.timeUntilDespawn)
         buffer.p1(message.ownershipType)
-        buffer.p1Alt1(message.opFlags.value)
+        buffer.p1Alt1(message.opFlags.toInt())
         buffer.p1(if (message.neverBecomesPublic) 1 else 0)
         buffer.p1Alt1(message.coordInZonePacked)
     }

--- a/protocol/osrs-221/osrs-221-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/ObjOpFilterEncoder.kt
+++ b/protocol/osrs-221/osrs-221-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/ObjOpFilterEncoder.kt
@@ -16,7 +16,7 @@ public class ObjOpFilterEncoder : ZoneProtEncoder<ObjOpFilter> {
         // The function at the bottom of the OBJ_OPFILTER has a consistent order,
         // making it easy to identify all the properties of this packet:
         // obj_opfilter(level, x, z, id, opFlags)
-        buffer.p1(message.opFlags.value)
+        buffer.p1(message.opFlags.toInt())
         buffer.p2Alt3(message.id)
         buffer.p1Alt1(message.coordInZonePacked)
     }

--- a/protocol/osrs-221/osrs-221-internal/src/main/kotlin/net/rsprot/protocol/common/game/outgoing/inv/internal/Inventory.kt
+++ b/protocol/osrs-221/osrs-221-internal/src/main/kotlin/net/rsprot/protocol/common/game/outgoing/inv/internal/Inventory.kt
@@ -37,8 +37,8 @@ public class Inventory private constructor(
      * @throws ArrayIndexOutOfBoundsException if the inventory is full
      */
     @Throws(ArrayIndexOutOfBoundsException::class)
-    public fun add(obj: InventoryObject) {
-        contents[count++] = obj.packed
+    public fun add(obj: Long) {
+        contents[count++] = obj
     }
 
     /**
@@ -48,7 +48,7 @@ public class Inventory private constructor(
      * @throws ArrayIndexOutOfBoundsException if the index is out of bounds
      */
     @Throws(ArrayIndexOutOfBoundsException::class)
-    public operator fun get(slot: Int): InventoryObject = InventoryObject(contents[slot])
+    public operator fun get(slot: Int): Long = contents[slot]
 
     /**
      * Clears the inventory by setting the count to zero.

--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/incoming/events/EventKeyboard.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/incoming/events/EventKeyboard.kt
@@ -55,8 +55,7 @@ public class EventKeyboard(
      * format back into the normalized [java.awt.event.KeyEvent] format.
      * @property length the length of the key sequence
      */
-    @JvmInline
-    public value class KeySequence(
+    public class KeySequence(
         private val array: ByteArray,
     ) {
         public val length: Int

--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/incoming/events/EventMouseMove.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/incoming/events/EventMouseMove.kt
@@ -56,13 +56,12 @@ public class EventMouseMove private constructor(
             ")"
 
     /**
-     * A value class that wraps around an array of mouse movements,
+     * A class that wraps around an array of mouse movements,
      * with the encoding specified by [MousePosChange].
      * @property length the number of mouse movements in this packet.
      */
     @Suppress("MemberVisibilityCanBePrivate")
-    @JvmInline
-    public value class MouseMovements(
+    public class MouseMovements(
         private val movements: LongArray,
     ) {
         public val length: Int
@@ -89,7 +88,7 @@ public class EventMouseMove private constructor(
         public fun getMousePosChange(index: Int): MousePosChange = MousePosChange(movements[index])
 
         /**
-         * A value class for mouse position changes, packed into a primitive long.
+         * A class for mouse position changes, packed into a primitive long.
          * We utilize bitpacking in order to use primitive long arrays for space
          * constraints.
          * @property packed the bitpacked long value, exposed as servers may wish
@@ -102,8 +101,7 @@ public class EventMouseMove private constructor(
          * mouse goes outside the client window, the value will be -1.
          */
         @Suppress("MemberVisibilityCanBePrivate")
-        @JvmInline
-        public value class MousePosChange(
+        public class MousePosChange(
             public val packed: Long,
         ) {
             public constructor(
@@ -111,10 +109,7 @@ public class EventMouseMove private constructor(
                 xDelta: Int,
                 yDelta: Int,
             ) : this(
-                (timeDelta and 0xFFFF)
-                    .toLong()
-                    .or(xDelta.toLong() and 0xFFFF shl 16)
-                    .or(yDelta.toLong() and 0xFFFF shl 32),
+                pack(timeDelta, xDelta, yDelta),
             )
 
             public val timeDelta: Int
@@ -130,6 +125,18 @@ public class EventMouseMove private constructor(
                     "xDelta=$xDelta, " +
                     "yDelta=$yDelta" +
                     ")"
+
+            public companion object {
+                public fun pack(
+                    timeDelta: Int,
+                    xDelta: Int,
+                    yDelta: Int,
+                ): Long =
+                    (timeDelta and 0xFFFF)
+                        .toLong()
+                        .or(xDelta.toLong() and 0xFFFF shl 16)
+                        .or(yDelta.toLong() and 0xFFFF shl 32)
+            }
         }
     }
 }

--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/incoming/messaging/MessagePublic.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/incoming/messaging/MessagePublic.kt
@@ -141,14 +141,13 @@ public class MessagePublic private constructor(
             ")"
 
     /**
-     * A value class for message colour patterns, allowing easy
+     * A class for message colour patterns, allowing easy
      * conversion from the byte array to the respective 24-bit RGB colours.
      * This wrapper class additionally provides a helpful [isValid] function,
      * as it is possible to otherwise send bad data from the client and
      * crash the players in vicinity.
      */
-    @JvmInline
-    public value class MessageColourPattern(
+    public class MessageColourPattern(
         private val bytes: ByteArray,
     ) {
         public val length: Int

--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfo.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfo.kt
@@ -203,6 +203,25 @@ public class NpcInfo internal constructor(
     }
 
     /**
+     * Updates the build area for this NPC info.
+     * This will ensure that no NPCs outside of this box will be
+     * added to high resolution view.
+     * @param zoneX the south-western zone x coordinate of the build area
+     * @param zoneZ the south-western zone z coordinate of the build area
+     * @param widthInZones the build area width in zones (typically 13, meaning 104 tiles)
+     * @param heightInZones the build area height in zones (typically 13, meaning 104 tiles)
+     */
+    @JvmOverloads
+    public fun updateBuildArea(
+        zoneX: Int,
+        zoneZ: Int,
+        widthInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+        heightInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+    ) {
+        this.buildArea = BuildArea(zoneX, zoneZ, widthInZones, heightInZones)
+    }
+
+    /**
      * Allocates a new buffer from the [allocator] with a capacity of [BUF_CAPACITY].
      * The old [buffer] will not be released, as that is the duty of the encoder class.
      */

--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
@@ -188,6 +188,25 @@ public class PlayerInfo internal constructor(
     }
 
     /**
+     * Updates the build area of this player info object.
+     * This will ensure that no players outside of this box will be
+     * added to high resolution view.
+     * @param zoneX the south-western zone x coordinate of the build area
+     * @param zoneZ the south-western zone z coordinate of the build area
+     * @param widthInZones the build area width in zones (typically 13, meaning 104 tiles)
+     * @param heightInZones the build area height in zones (typically 13, meaning 104 tiles)
+     */
+    @JvmOverloads
+    public fun updateBuildArea(
+        zoneX: Int,
+        zoneZ: Int,
+        widthInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+        heightInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+    ) {
+        this.buildArea = BuildArea(zoneX, zoneZ, widthInZones, heightInZones)
+    }
+
+    /**
      * Turns the player info object into a wrapped packet.
      * This is necessary because the encoder itself is only triggered in Netty, and it is possible
      * that the buffer has already been replaced with a new variant before it gets to that stage.

--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/inv/UpdateInvFull.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/inv/UpdateInvFull.kt
@@ -87,14 +87,14 @@ public class UpdateInvFull private constructor(
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
 
     /**
-     * Gets the obj in the [slot] provided.
+     * Gets the bitpacked obj in the [slot] provided.
      * @param slot the slot in the inventory.
      * @return the inventory object that's in that slot,
      * or [InventoryObject.NULL] if there's no object.
      * @throws IndexOutOfBoundsException if the [slot] is outside
      * the inventory's boundaries.
      */
-    public fun getObject(slot: Int): InventoryObject = inventory[slot]
+    public fun getObject(slot: Int): Long = inventory[slot]
 
     public fun returnInventory() {
         inventory.clear()
@@ -138,11 +138,11 @@ public class UpdateInvFull private constructor(
      */
     public fun interface ObjectProvider {
         /**
-         * Provides an [InventoryObject] instance for a given slot
+         * Provides an [InventoryObject] for a given slot
          * in inventory. If there is no object in that slot,
          * use [InventoryObject.NULL] as an indicator of it.
          */
-        public fun provide(slot: Int): InventoryObject
+        public fun provide(slot: Int): Long
     }
 
     private companion object {
@@ -153,7 +153,7 @@ public class UpdateInvFull private constructor(
          * @param provider the object provider, used to return information
          * about an object in a slot of an inventory.
          * @return an inventory object, which is a compressed representation
-         * of a list of [InventoryObject]s, backed by a long array.
+         * of a list of [InventoryObject]s as longs, backed by a long array.
          */
         private fun buildInventory(
             capacity: Int,
@@ -163,7 +163,7 @@ public class UpdateInvFull private constructor(
             for (i in 0..<capacity) {
                 val obj = provider.provide(i)
                 if (RSProtFlags.inventoryObjCheck) {
-                    check(obj == InventoryObject.NULL || obj.count >= 0) {
+                    check(obj == InventoryObject.NULL || InventoryObject.getCount(obj) >= 0) {
                         "Obj count cannot be below zero: $obj @ $i"
                     }
                 }

--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/inv/UpdateInvPartial.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/inv/UpdateInvPartial.kt
@@ -103,14 +103,14 @@ public class UpdateInvPartial private constructor(
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
 
     /**
-     * Gets the obj in the [slot] provided.
+     * Gets the bitpacked obj in the [slot] provided.
      * @param slot the slot in the inventory.
      * @return the inventory object that's in that slot,
      * or [InventoryObject.NULL] if there's no object.
      * @throws IndexOutOfBoundsException if the [slot] is outside
      * the inventory's boundaries.
      */
-    public fun getObject(slot: Int): InventoryObject = inventory[slot]
+    public fun getObject(slot: Int): Long = inventory[slot]
 
     public fun returnInventory() {
         inventory.clear()
@@ -156,11 +156,11 @@ public class UpdateInvPartial private constructor(
         internal val indices: Iterator<Int>,
     ) {
         /**
-         * Provides an [InventoryObject] instance for a given slot
+         * Provides an [InventoryObject] for a given slot
          * in inventory. If there is no object in that slot,
          * use [InventoryObject.NULL] as an indicator of it.
          */
-        public abstract fun provide(slot: Int): InventoryObject
+        public abstract fun provide(slot: Int): Long
     }
 
     private companion object {
@@ -169,7 +169,7 @@ public class UpdateInvPartial private constructor(
          * @param provider the object provider, used to return information
          * about an object in a slot of an inventory.
          * @return an inventory object, which is a compressed representation
-         * of a list of [InventoryObject]s, backed by a long array.
+         * of a list of [InventoryObject]s as longs, backed by a long array.
          */
         private fun buildInventory(provider: IndexedObjectProvider): Inventory {
             val inventory = InventoryPool.pool.borrowObject()
@@ -180,10 +180,10 @@ public class UpdateInvPartial private constructor(
                         "Obj cannot be InventoryObject.NULL for partial updates. Use InventoryObject(slot, -1, -1) " +
                             "instead."
                     }
-                    check(obj.slot >= 0) {
+                    check(InventoryObject.getSlot(obj) >= 0) {
                         "Obj slot cannot be below zero: $obj $ $index"
                     }
-                    check(obj.id == -1 || obj.count >= 0) {
+                    check(InventoryObject.getId(obj) == -1 || InventoryObject.getCount(obj) >= 0) {
                         "Obj count cannot be below zero: $obj @ $index"
                     }
                 }

--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/RebuildRegion.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/RebuildRegion.kt
@@ -136,6 +136,15 @@ public class RebuildRegion private constructor(
             key,
         )
 
+        public val rotation: Int
+            get() = referenceZone.rotation
+        public val zoneX: Int
+            get() = referenceZone.zoneX
+        public val zoneZ: Int
+            get() = referenceZone.zoneZ
+        public val level: Int
+            get() = referenceZone.level
+
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             if (javaClass != other?.javaClass) return false

--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/util/OpFlags.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/util/OpFlags.kt
@@ -3,70 +3,50 @@ package net.rsprot.protocol.game.outgoing.util
 /**
  * Op flags are used to hide or show certain right-click options on various
  * interactable entities.
- * This is a helper class to create
+ * This is a helper class to create various combinations of this flag.
  */
 @Suppress("MemberVisibilityCanBePrivate")
-@JvmInline
-public value class OpFlags(
-    private val packed: Byte,
-) {
-    public constructor(
+public object OpFlags {
+    /**
+     * A constant flag for 'show all options' on an entity.
+     */
+    public const val ALL_SHOWN: Byte = -1
+
+    /**
+     * A constant flag for 'show no options' on an entity.
+     */
+    public const val NONE_SHOWN: Byte = 0
+
+    @JvmSynthetic
+    public operator fun invoke(
         op1: Boolean,
         op2: Boolean,
         op3: Boolean,
         op4: Boolean,
         op5: Boolean,
-    ) : this(
+    ): Byte = ofOps(op1, op2, op3, op4, op5)
+
+    /**
+     * Returns the bitpacked op flag out of the provided booleans.
+     */
+    @JvmStatic
+    public fun ofOps(
+        op1: Boolean,
+        op2: Boolean,
+        op3: Boolean,
+        op4: Boolean,
+        op5: Boolean,
+    ): Byte =
         toInt(op1)
             .or(toInt(op2) shl 1)
             .or(toInt(op3) shl 2)
             .or(toInt(op4) shl 3)
             .or(toInt(op5) shl 4)
-            .toByte(),
-    )
-
-    public val value: Int
-        get() = packed.toInt()
+            .toByte()
 
     /**
-     * Checks if an option is enabled.
-     * @param op the id of the option, in range of 1 to 5 (inclusive).
-     * @return whether the given option is enabled.
-     * @throws IllegalArgumentException if the option is out of bounds (not in range of 1..5)
+     * Turns the boolean to an integer.
+     * @return 1 if the boolean is enabled, 0 otherwise.
      */
-    public fun isEnabled(op: Int): Boolean {
-        require(op in 1..5) {
-            "Unexpected op value: $op"
-        }
-        val index = op - 1
-        val flag = 1 shl index
-        return packed.toInt() and flag != 0
-    }
-
-    override fun toString(): String =
-        "OpFlags(" +
-            "op1=${isEnabled(1)}, " +
-            "op2=${isEnabled(2)}, " +
-            "op3=${isEnabled(3)}, " +
-            "op4=${isEnabled(4)}, " +
-            "op5=${isEnabled(5)}" +
-            ")"
-
-    public companion object {
-        /**
-         * A constant flag for 'show all options' on an entity.
-         */
-        public val ALL_SHOWN: OpFlags = OpFlags(-1)
-
-        /**
-         * A constant flag for 'show no options' on an entity.
-         */
-        public val NONE_SHOWN: OpFlags = OpFlags(0)
-
-        /**
-         * Turns the boolean to an integer.
-         * @return 1 if the boolean is enabled, 0 otherwise.
-         */
-        private fun toInt(value: Boolean): Int = if (value) 1 else 0
-    }
+    private fun toInt(value: Boolean): Int = if (value) 1 else 0
 }

--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/LocAddChange.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/LocAddChange.kt
@@ -3,7 +3,6 @@ package net.rsprot.protocol.game.outgoing.zone.payload
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.common.game.outgoing.codec.zone.payload.OldSchoolZoneProt
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
-import net.rsprot.protocol.game.outgoing.util.OpFlags
 import net.rsprot.protocol.game.outgoing.zone.payload.util.CoordInZone
 import net.rsprot.protocol.game.outgoing.zone.payload.util.LocProperties
 import net.rsprot.protocol.message.ZoneProt
@@ -21,12 +20,14 @@ import net.rsprot.protocol.message.ZoneProt
  * @property shape the shape of the loc, a value of 0 to 22 (inclusive) is expected.
  * @property rotation the rotation of the loc, a value of 0 to 3 (inclusive) is expected.
  * @property opFlags the right-click options enabled on this loc.
+ * Use the [net.rsprot.protocol.game.outgoing.util.OpFlags] helper object to create these
+ * bitpacked values which can be passed into it.
  */
 public class LocAddChange private constructor(
     private val _id: UShort,
     private val coordInZone: CoordInZone,
     private val locProperties: LocProperties,
-    public val opFlags: OpFlags,
+    public val opFlags: Byte,
 ) : ZoneProt {
     public constructor(
         id: Int,
@@ -34,7 +35,7 @@ public class LocAddChange private constructor(
         zInZone: Int,
         shape: Int,
         rotation: Int,
-        opFlags: OpFlags,
+        opFlags: Byte,
     ) : this(
         id.toUShort(),
         CoordInZone(xInZone, zInZone),

--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/ObjAdd.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/ObjAdd.kt
@@ -3,7 +3,6 @@ package net.rsprot.protocol.game.outgoing.zone.payload
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.common.game.outgoing.codec.zone.payload.OldSchoolZoneProt
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
-import net.rsprot.protocol.game.outgoing.util.OpFlags
 import net.rsprot.protocol.game.outgoing.zone.payload.util.CoordInZone
 import net.rsprot.protocol.message.ZoneProt
 
@@ -27,6 +26,8 @@ import net.rsprot.protocol.message.ZoneProt
  * @property zInZone the z coordinate of the obj within the zone it is in,
  * a value in range of 0 to 7 (inclusive) is expected. Any bits outside that are ignored.
  * @property opFlags the right-click options enabled on this obj.
+ * Use the [net.rsprot.protocol.game.outgoing.util.OpFlags] helper object to create these
+ * bitpacked values which can be passed into it.
  * @property timeUntilPublic how many game cycles until the obj turns public.
  * This property is only used on the C++-based clients.
  * @property timeUntilDespawn how many game cycles until the obj disappears.
@@ -41,7 +42,7 @@ public class ObjAdd private constructor(
     private val _id: UShort,
     public val quantity: Int,
     private val coordInZone: CoordInZone,
-    public val opFlags: OpFlags,
+    public val opFlags: Byte,
     private val _timeUntilPublic: UShort,
     private val _timeUntilDespawn: UShort,
     private val _ownershipType: UByte,
@@ -52,7 +53,7 @@ public class ObjAdd private constructor(
         quantity: Int,
         xInZone: Int,
         zInZone: Int,
-        opFlags: OpFlags,
+        opFlags: Byte,
         timeUntilPublic: Int,
         timeUntilDespawn: Int,
         ownershipType: Int,
@@ -78,7 +79,7 @@ public class ObjAdd private constructor(
         quantity: Int,
         xInZone: Int,
         zInZone: Int,
-        opFlags: OpFlags,
+        opFlags: Byte,
     ) : this(
         id,
         quantity,

--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/ObjOpFilter.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/ObjOpFilter.kt
@@ -3,7 +3,6 @@ package net.rsprot.protocol.game.outgoing.zone.payload
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.common.game.outgoing.codec.zone.payload.OldSchoolZoneProt
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
-import net.rsprot.protocol.game.outgoing.util.OpFlags
 import net.rsprot.protocol.game.outgoing.zone.payload.util.CoordInZone
 import net.rsprot.protocol.message.ZoneProt
 
@@ -13,7 +12,9 @@ import net.rsprot.protocol.message.ZoneProt
  * It works by finding the first obj in the stack with the provided [id],
  * and modifying the right-click ops on that. It does not verify quantity.
  * @property id the id of the obj that needs to get its ops changed
- * @property opFlags the right-click options to set enabled on that obj
+ * @property opFlags the right-click options to set enabled on that obj.
+ * Use the [net.rsprot.protocol.game.outgoing.util.OpFlags] helper object to create these
+ * bitpacked values which can be passed into it.
  * @property xInZone the x coordinate of the obj within the zone it is in,
  * a value in range of 0 to 7 (inclusive) is expected. Any bits outside that are ignored.
  * @property zInZone the z coordinate of the obj within the zone it is in,
@@ -21,12 +22,12 @@ import net.rsprot.protocol.message.ZoneProt
  */
 public class ObjOpFilter private constructor(
     private val _id: UShort,
-    public val opFlags: OpFlags,
+    public val opFlags: Byte,
     private val coordInZone: CoordInZone,
 ) : ZoneProt {
     public constructor(
         id: Int,
-        opFlags: OpFlags,
+        opFlags: Byte,
         xInZone: Int,
         zInZone: Int,
     ) : this(

--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/pow/challenges/sha256/DefaultSha256ProofOfWorkProvider.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/pow/challenges/sha256/DefaultSha256ProofOfWorkProvider.kt
@@ -4,12 +4,11 @@ import net.rsprot.protocol.loginprot.incoming.pow.ProofOfWorkProvider
 import net.rsprot.protocol.loginprot.incoming.pow.SingleTypeProofOfWorkProvider
 
 /**
- * A value class to wrap the properties of a SHA-256 into a single instance.
+ * A class to wrap the properties of a SHA-256 into a single instance.
  * @property provider the SHA-256 proof of work provider.
  */
 @Suppress("MemberVisibilityCanBePrivate")
-@JvmInline
-public value class DefaultSha256ProofOfWorkProvider private constructor(
+public class DefaultSha256ProofOfWorkProvider private constructor(
     public val provider: SingleTypeProofOfWorkProvider<Sha256Challenge, Sha256MetaData>,
 ) : ProofOfWorkProvider<Sha256Challenge, Sha256MetaData> by provider {
     public constructor(

--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/Password.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/Password.kt
@@ -1,12 +1,11 @@
 package net.rsprot.protocol.loginprot.incoming.util
 
 /**
- * A value class to hold the password.
+ * A class to hold the password.
  * This class offers additional functionality to clear the data from memory,
  * to avoid any potential memory attacks.
  */
-@JvmInline
-public value class Password(
+public class Password(
     public val data: ByteArray,
 ) {
     /**

--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/Token.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/Token.kt
@@ -1,12 +1,11 @@
 package net.rsprot.protocol.loginprot.incoming.util
 
 /**
- * A value class to hold the login token.
+ * A class to hold the login token.
  * This class offers additional functionality to clear the data from memory,
  * to avoid any potential memory attacks.
  */
-@JvmInline
-public value class Token(
+public class Token(
     public val data: ByteArray,
 ) {
     /**

--- a/protocol/osrs-222/osrs-222-common/src/main/kotlin/net/rsprot/protocol/common/game/outgoing/inv/InventoryObject.kt
+++ b/protocol/osrs-222/osrs-222-common/src/main/kotlin/net/rsprot/protocol/common/game/outgoing/inv/InventoryObject.kt
@@ -1,63 +1,50 @@
 package net.rsprot.protocol.common.game.outgoing.inv
 
 /**
- * Inventory objects are a value class around the primitive 'long'
- * to efficiently compress an inventory's contents into a long array.
- * This allows us to avoid any garbage creation that would otherwise
- * be created by making lists of objs repeatedly.
+ * Inventory object is a helper object built around the primitive 'long' type.
+ * We utilize longs directly here to reduce the effects of garbage creation
+ * via inventories, as this can otherwise get quite severe with a lot of players.
  */
-@JvmInline
-public value class InventoryObject(
-    public val packed: Long,
-) {
-    public constructor(
+public object InventoryObject {
+    public const val NULL: Long = -1
+
+    @JvmSynthetic
+    public operator fun invoke(
         slot: Int,
         id: Int,
         count: Int,
-    ) : this(
-        (slot.toLong() and 0xFFFF)
-            .or((id.toLong() and 0xFFFF) shl 16)
-            .or((count.toLong() and 0xFFFFFFFF) shl 32),
-    )
+    ): Long = pack(slot, id, count)
 
-    public constructor(
+    @JvmStatic
+    public fun pack(
+        slot: Int,
         id: Int,
         count: Int,
-    ) : this(
-        0,
-        id,
-        count,
-    )
+    ): Long =
+        (slot.toLong() and 0xFFFF)
+            .or((id.toLong() and 0xFFFF) shl 16)
+            .or((count.toLong() and 0xFFFFFFFF) shl 32)
 
-    public val slot: Int
-        get() {
-            val value = (packed and 0xFFFF).toInt()
-            return if (value == 0xFFFF) {
-                -1
-            } else {
-                value
-            }
+    @JvmStatic
+    public fun getSlot(packed: Long): Int {
+        val value = (packed and 0xFFFF).toInt()
+        return if (value == 0xFFFF) {
+            -1
+        } else {
+            value
         }
-    public val id: Int
-        get() {
-            val value = (packed ushr 16 and 0xFFFF).toInt()
-            return if (value == 0xFFFF) {
-                -1
-            } else {
-                value
-            }
-        }
-    public val count: Int
-        get() = (packed ushr 32).toInt()
-
-    override fun toString(): String =
-        "InventoryObject(" +
-            "slot=$slot, " +
-            "id=$id, " +
-            "count=$count" +
-            ")"
-
-    public companion object {
-        public val NULL: InventoryObject = InventoryObject(-1)
     }
+
+    @JvmStatic
+    public fun getId(packed: Long): Int {
+        val value = (packed ushr 16 and 0xFFFF).toInt()
+        return if (value == 0xFFFF) {
+            -1
+        } else {
+            value
+        }
+    }
+
+    @JvmStatic
+    public fun getCount(packed: Long): Int = (packed ushr 32).toInt()
 }

--- a/protocol/osrs-222/osrs-222-desktop/src/main/kotlin/net/rsprot/protocol/game/incoming/codec/events/EventMouseMoveDecoder.kt
+++ b/protocol/osrs-222/osrs-222-desktop/src/main/kotlin/net/rsprot/protocol/game/incoming/codec/events/EventMouseMoveDecoder.kt
@@ -50,12 +50,12 @@ public class EventMouseMoveDecoder : MessageDecoder<EventMouseMove> {
                 deltaY = (packed and 0x3F) - 32
             }
             val change =
-                MouseMovements.MousePosChange(
+                MouseMovements.MousePosChange.pack(
                     timeSinceLastMovement,
                     deltaX,
                     deltaY,
                 )
-            array[count++] = change.packed
+            array[count++] = change
         }
         val slice = array.copyOf(count)
         return EventMouseMove(

--- a/protocol/osrs-222/osrs-222-desktop/src/main/kotlin/net/rsprot/protocol/game/incoming/codec/events/EventNativeMouseMoveDecoder.kt
+++ b/protocol/osrs-222/osrs-222-desktop/src/main/kotlin/net/rsprot/protocol/game/incoming/codec/events/EventNativeMouseMoveDecoder.kt
@@ -50,12 +50,12 @@ public class EventNativeMouseMoveDecoder : MessageDecoder<EventNativeMouseMove> 
                 deltaY = (packed and 0x3F) - 32
             }
             val change =
-                MouseMovements.MousePosChange(
+                MouseMovements.MousePosChange.pack(
                     timeSinceLastMovement,
                     deltaX,
                     deltaY,
                 )
-            array[count++] = change.packed
+            array[count++] = change
         }
         val slice = array.copyOf(count)
         return EventNativeMouseMove(

--- a/protocol/osrs-222/osrs-222-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/inv/UpdateInvFullEncoder.kt
+++ b/protocol/osrs-222/osrs-222-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/inv/UpdateInvFullEncoder.kt
@@ -28,8 +28,8 @@ public class UpdateInvFullEncoder : MessageEncoder<UpdateInvFull> {
                 buffer.p1Alt2(0)
                 continue
             }
-            buffer.p2Alt3(obj.id + 1)
-            val count = obj.count
+            buffer.p2Alt3(InventoryObject.getId(obj) + 1)
+            val count = InventoryObject.getCount(obj)
             buffer.p1Alt2(count.coerceAtMost(0xFF))
             if (count >= 255) {
                 buffer.p4Alt2(count)

--- a/protocol/osrs-222/osrs-222-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/inv/UpdateInvPartialEncoder.kt
+++ b/protocol/osrs-222/osrs-222-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/inv/UpdateInvPartialEncoder.kt
@@ -3,6 +3,7 @@ package net.rsprot.protocol.game.outgoing.codec.inv
 import net.rsprot.buffer.JagByteBuf
 import net.rsprot.crypto.cipher.StreamCipher
 import net.rsprot.protocol.ServerProt
+import net.rsprot.protocol.common.game.outgoing.inv.InventoryObject
 import net.rsprot.protocol.game.outgoing.inv.UpdateInvPartial
 import net.rsprot.protocol.game.outgoing.prot.GameServerProt
 import net.rsprot.protocol.message.codec.MessageEncoder
@@ -22,14 +23,14 @@ public class UpdateInvPartialEncoder : MessageEncoder<UpdateInvPartial> {
         buffer.p2(message.inventoryId)
         for (i in 0..<message.count) {
             val obj = message.getObject(i)
-            buffer.pSmart1or2(obj.slot)
-            val id = obj.id
+            buffer.pSmart1or2(InventoryObject.getSlot(obj))
+            val id = InventoryObject.getId(obj)
             if (id == -1) {
                 buffer.p2(0)
                 continue
             }
             buffer.p2(id + 1)
-            val count = obj.count
+            val count = InventoryObject.getCount(obj)
             buffer.p1(count.coerceAtMost(0xFF))
             if (count >= 0xFF) {
                 buffer.p4(count)

--- a/protocol/osrs-222/osrs-222-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/LocAddChangeEncoder.kt
+++ b/protocol/osrs-222/osrs-222-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/LocAddChangeEncoder.kt
@@ -16,7 +16,7 @@ public class LocAddChangeEncoder : ZoneProtEncoder<LocAddChange> {
         // The function at the bottom of the LOC_ADD_CHANGE has a consistent order,
         // making it easy to identify all the properties of this packet:
         // loc_add_change_del(world, level, x, z, layer, id, shape, rotation, opFlags, 0, -1)
-        buffer.p1(message.opFlags.value)
+        buffer.p1(message.opFlags.toInt())
         buffer.p1Alt1(message.coordInZonePacked)
         buffer.p1Alt1(message.locPropertiesPacked)
         buffer.p2Alt2(message.id)

--- a/protocol/osrs-222/osrs-222-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/ObjAddEncoder.kt
+++ b/protocol/osrs-222/osrs-222-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/ObjAddEncoder.kt
@@ -24,6 +24,6 @@ public class ObjAddEncoder : ZoneProtEncoder<ObjAdd> {
         buffer.p1(message.ownershipType)
         buffer.p1(if (message.neverBecomesPublic) 1 else 0)
         buffer.p1Alt3(message.coordInZonePacked)
-        buffer.p1Alt3(message.opFlags.value)
+        buffer.p1Alt3(message.opFlags.toInt())
     }
 }

--- a/protocol/osrs-222/osrs-222-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/ObjOpFilterEncoder.kt
+++ b/protocol/osrs-222/osrs-222-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/ObjOpFilterEncoder.kt
@@ -17,7 +17,7 @@ public class ObjOpFilterEncoder : ZoneProtEncoder<ObjOpFilter> {
         // making it easy to identify all the properties of this packet:
         // obj_opfilter(level, x, z, id, opFlags)
         buffer.p2(message.id)
-        buffer.p1Alt2(message.opFlags.value)
+        buffer.p1Alt2(message.opFlags.toInt())
         buffer.p1Alt1(message.coordInZonePacked)
     }
 }

--- a/protocol/osrs-222/osrs-222-internal/src/main/kotlin/net/rsprot/protocol/common/game/outgoing/inv/internal/Inventory.kt
+++ b/protocol/osrs-222/osrs-222-internal/src/main/kotlin/net/rsprot/protocol/common/game/outgoing/inv/internal/Inventory.kt
@@ -37,8 +37,8 @@ public class Inventory private constructor(
      * @throws ArrayIndexOutOfBoundsException if the inventory is full
      */
     @Throws(ArrayIndexOutOfBoundsException::class)
-    public fun add(obj: InventoryObject) {
-        contents[count++] = obj.packed
+    public fun add(obj: Long) {
+        contents[count++] = obj
     }
 
     /**
@@ -48,7 +48,7 @@ public class Inventory private constructor(
      * @throws ArrayIndexOutOfBoundsException if the index is out of bounds
      */
     @Throws(ArrayIndexOutOfBoundsException::class)
-    public operator fun get(slot: Int): InventoryObject = InventoryObject(contents[slot])
+    public operator fun get(slot: Int): Long = contents[slot]
 
     /**
      * Clears the inventory by setting the count to zero.

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/incoming/events/EventKeyboard.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/incoming/events/EventKeyboard.kt
@@ -55,8 +55,7 @@ public class EventKeyboard(
      * format back into the normalized [java.awt.event.KeyEvent] format.
      * @property length the length of the key sequence
      */
-    @JvmInline
-    public value class KeySequence(
+    public class KeySequence(
         private val array: ByteArray,
     ) {
         public val length: Int

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/incoming/events/util/MouseMovements.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/incoming/events/util/MouseMovements.kt
@@ -1,13 +1,12 @@
 package net.rsprot.protocol.game.incoming.events.util
 
 /**
- * A value class that wraps around an array of mouse movements,
+ * A class that wraps around an array of mouse movements,
  * with the encoding specified by [MousePosChange].
  * @property length the number of mouse movements in this packet.
  */
 @Suppress("MemberVisibilityCanBePrivate")
-@JvmInline
-public value class MouseMovements(
+public class MouseMovements(
     private val movements: LongArray,
 ) {
     public val length: Int
@@ -34,7 +33,7 @@ public value class MouseMovements(
     public fun getMousePosChange(index: Int): MousePosChange = MousePosChange(movements[index])
 
     /**
-     * A value class for mouse position changes, packed into a primitive long.
+     * A class for mouse position changes, packed into a primitive long.
      * We utilize bitpacking in order to use primitive long arrays for space
      * constraints.
      * @property packed the bitpacked long value, exposed as servers may wish
@@ -47,8 +46,7 @@ public value class MouseMovements(
      * mouse goes outside the client window, the value will be -1.
      */
     @Suppress("MemberVisibilityCanBePrivate")
-    @JvmInline
-    public value class MousePosChange(
+    public class MousePosChange(
         public val packed: Long,
     ) {
         public constructor(
@@ -56,10 +54,7 @@ public value class MouseMovements(
             xDelta: Int,
             yDelta: Int,
         ) : this(
-            (timeDelta and 0xFFFF)
-                .toLong()
-                .or(xDelta.toLong() and 0xFFFF shl 16)
-                .or(yDelta.toLong() and 0xFFFF shl 32),
+            pack(timeDelta, xDelta, yDelta),
         )
 
         public val timeDelta: Int
@@ -75,5 +70,17 @@ public value class MouseMovements(
                 "xDelta=$xDelta, " +
                 "yDelta=$yDelta" +
                 ")"
+
+        public companion object {
+            public fun pack(
+                timeDelta: Int,
+                xDelta: Int,
+                yDelta: Int,
+            ): Long =
+                (timeDelta and 0xFFFF)
+                    .toLong()
+                    .or(xDelta.toLong() and 0xFFFF shl 16)
+                    .or(yDelta.toLong() and 0xFFFF shl 32)
+        }
     }
 }

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/incoming/messaging/MessagePublic.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/incoming/messaging/MessagePublic.kt
@@ -141,14 +141,13 @@ public class MessagePublic private constructor(
             ")"
 
     /**
-     * A value class for message colour patterns, allowing easy
+     * A class for message colour patterns, allowing easy
      * conversion from the byte array to the respective 24-bit RGB colours.
      * This wrapper class additionally provides a helpful [isValid] function,
      * as it is possible to otherwise send bad data from the client and
      * crash the players in vicinity.
      */
-    @JvmInline
-    public value class MessageColourPattern(
+    public class MessageColourPattern(
         private val bytes: ByteArray,
     ) {
         public val length: Int

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfo.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfo.kt
@@ -89,6 +89,32 @@ public class NpcInfo internal constructor(
     }
 
     /**
+     * Updates the build area of a given world to the specified one.
+     * This will ensure that no NPCs outside of this box will be
+     * added to high resolution view.
+     * @param worldId the id of the world to set the build area of,
+     * with -1 being the root world.
+     * @param zoneX the south-western zone x coordinate of the build area
+     * @param zoneZ the south-western zone z coordinate of the build area
+     * @param widthInZones the build area width in zones (typically 13, meaning 104 tiles)
+     * @param heightInZones the build area height in zones (typically 13, meaning 104 tiles)
+     */
+    @JvmOverloads
+    public fun updateBuildArea(
+        worldId: Int,
+        zoneX: Int,
+        zoneZ: Int,
+        widthInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+        heightInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+    ) {
+        require(worldId == ROOT_WORLD || worldId in 0..<2048) {
+            "World id must be -1 or in range of 0..<2048"
+        }
+        val details = getDetails(worldId)
+        details.buildArea = BuildArea(zoneX, zoneZ, widthInZones, heightInZones)
+    }
+
+    /**
      * Allocates a new NPC info tracking object for the respective [worldId],
      * keeping track of everyone that's within this new world entity.
      * @param worldId the new world entity id

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
@@ -176,6 +176,32 @@ public class PlayerInfo internal constructor(
     }
 
     /**
+     * Updates the build area of a given world to the specified one.
+     * This will ensure that no players outside of this box will be
+     * added to high resolution view.
+     * @param worldId the id of the world to set the build area of,
+     * with -1 being the root world.
+     * @param zoneX the south-western zone x coordinate of the build area
+     * @param zoneZ the south-western zone z coordinate of the build area
+     * @param widthInZones the build area width in zones (typically 13, meaning 104 tiles)
+     * @param heightInZones the build area height in zones (typically 13, meaning 104 tiles)
+     */
+    @JvmOverloads
+    public fun updateBuildArea(
+        worldId: Int,
+        zoneX: Int,
+        zoneZ: Int,
+        widthInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+        heightInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+    ) {
+        require(worldId == ROOT_WORLD || worldId in 0..<2048) {
+            "World id must be -1 or in range of 0..<2048"
+        }
+        val details = getDetails(worldId)
+        details.buildArea = BuildArea(zoneX, zoneZ, widthInZones, heightInZones)
+    }
+
+    /**
      * Allocates a new player info tracking object for the respective [worldId],
      * keeping track of everyone that's within this new world entity.
      * @param worldId the new world entity id

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityInfo.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityInfo.kt
@@ -113,6 +113,24 @@ public class WorldEntityInfo internal constructor(
     }
 
     /**
+     * Updates the build area for this player. This should always perfectly correspond to
+     * the actual build area that is sent via REBUILD_NORMAL or REBUILD_REGION packets.
+     * @property zoneX the south-western zone x coordinate of the build area
+     * @property zoneZ the south-western zone z coordinate of the build area
+     * @property widthInZones the build area width in zones (typically 13, meaning 104 tiles)
+     * @property heightInZones the build area height in zones (typically 13, meaning 104 tiles)
+     */
+    @JvmOverloads
+    public fun updateBuildArea(
+        zoneX: Int,
+        zoneZ: Int,
+        widthInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+        heightInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+    ) {
+        this.buildArea = BuildArea(zoneX, zoneZ, widthInZones, heightInZones)
+    }
+
+    /**
      * Gets a list of all the world entity indices that are currently in high resolution,
      * allowing for correct functionality for player and npc infos, as well as zone updates.
      * @return a list of indices of the world entities currently in high resolution.

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/inv/UpdateInvFull.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/inv/UpdateInvFull.kt
@@ -87,14 +87,14 @@ public class UpdateInvFull private constructor(
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
 
     /**
-     * Gets the obj in the [slot] provided.
+     * Gets the bitpacked obj in the [slot] provided.
      * @param slot the slot in the inventory.
      * @return the inventory object that's in that slot,
      * or [InventoryObject.NULL] if there's no object.
      * @throws IndexOutOfBoundsException if the [slot] is outside
      * the inventory's boundaries.
      */
-    public fun getObject(slot: Int): InventoryObject = inventory[slot]
+    public fun getObject(slot: Int): Long = inventory[slot]
 
     public fun returnInventory() {
         inventory.clear()
@@ -138,11 +138,11 @@ public class UpdateInvFull private constructor(
      */
     public fun interface ObjectProvider {
         /**
-         * Provides an [InventoryObject] instance for a given slot
+         * Provides an [InventoryObject] for a given slot
          * in inventory. If there is no object in that slot,
          * use [InventoryObject.NULL] as an indicator of it.
          */
-        public fun provide(slot: Int): InventoryObject
+        public fun provide(slot: Int): Long
     }
 
     private companion object {
@@ -153,7 +153,7 @@ public class UpdateInvFull private constructor(
          * @param provider the object provider, used to return information
          * about an object in a slot of an inventory.
          * @return an inventory object, which is a compressed representation
-         * of a list of [InventoryObject]s, backed by a long array.
+         * of a list of [InventoryObject]s as longs, backed by a long array.
          */
         private fun buildInventory(
             capacity: Int,
@@ -163,7 +163,7 @@ public class UpdateInvFull private constructor(
             for (i in 0..<capacity) {
                 val obj = provider.provide(i)
                 if (RSProtFlags.inventoryObjCheck) {
-                    check(obj == InventoryObject.NULL || obj.count >= 0) {
+                    check(obj == InventoryObject.NULL || InventoryObject.getCount(obj) >= 0) {
                         "Obj count cannot be below zero: $obj @ $i"
                     }
                 }

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/inv/UpdateInvPartial.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/inv/UpdateInvPartial.kt
@@ -103,14 +103,14 @@ public class UpdateInvPartial private constructor(
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
 
     /**
-     * Gets the obj in the [slot] provided.
+     * Gets the bitpacked obj in the [slot] provided.
      * @param slot the slot in the inventory.
      * @return the inventory object that's in that slot,
      * or [InventoryObject.NULL] if there's no object.
      * @throws IndexOutOfBoundsException if the [slot] is outside
      * the inventory's boundaries.
      */
-    public fun getObject(slot: Int): InventoryObject = inventory[slot]
+    public fun getObject(slot: Int): Long = inventory[slot]
 
     public fun returnInventory() {
         inventory.clear()
@@ -156,11 +156,11 @@ public class UpdateInvPartial private constructor(
         internal val indices: Iterator<Int>,
     ) {
         /**
-         * Provides an [InventoryObject] instance for a given slot
+         * Provides an [InventoryObject] for a given slot
          * in inventory. If there is no object in that slot,
          * use [InventoryObject.NULL] as an indicator of it.
          */
-        public abstract fun provide(slot: Int): InventoryObject
+        public abstract fun provide(slot: Int): Long
     }
 
     private companion object {
@@ -169,7 +169,7 @@ public class UpdateInvPartial private constructor(
          * @param provider the object provider, used to return information
          * about an object in a slot of an inventory.
          * @return an inventory object, which is a compressed representation
-         * of a list of [InventoryObject]s, backed by a long array.
+         * of a list of [InventoryObject]s as longs, backed by a long array.
          */
         private fun buildInventory(provider: IndexedObjectProvider): Inventory {
             val inventory = InventoryPool.pool.borrowObject()
@@ -180,10 +180,10 @@ public class UpdateInvPartial private constructor(
                         "Obj cannot be InventoryObject.NULL for partial updates. Use InventoryObject(slot, -1, -1) " +
                             "instead."
                     }
-                    check(obj.slot >= 0) {
+                    check(InventoryObject.getSlot(obj) >= 0) {
                         "Obj slot cannot be below zero: $obj $ $index"
                     }
-                    check(obj.id == -1 || obj.count >= 0) {
+                    check(InventoryObject.getId(obj) == -1 || InventoryObject.getCount(obj) >= 0) {
                         "Obj count cannot be below zero: $obj @ $index"
                     }
                 }

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/util/RebuildRegionZone.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/util/RebuildRegionZone.kt
@@ -28,6 +28,15 @@ public class RebuildRegionZone private constructor(
         key,
     )
 
+    public val rotation: Int
+        get() = referenceZone.rotation
+    public val zoneX: Int
+        get() = referenceZone.zoneX
+    public val zoneZ: Int
+        get() = referenceZone.zoneZ
+    public val level: Int
+        get() = referenceZone.level
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/util/OpFlags.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/util/OpFlags.kt
@@ -3,70 +3,50 @@ package net.rsprot.protocol.game.outgoing.util
 /**
  * Op flags are used to hide or show certain right-click options on various
  * interactable entities.
- * This is a helper class to create
+ * This is a helper class to create various combinations of this flag.
  */
 @Suppress("MemberVisibilityCanBePrivate")
-@JvmInline
-public value class OpFlags(
-    private val packed: Byte,
-) {
-    public constructor(
+public object OpFlags {
+    /**
+     * A constant flag for 'show all options' on an entity.
+     */
+    public const val ALL_SHOWN: Byte = -1
+
+    /**
+     * A constant flag for 'show no options' on an entity.
+     */
+    public const val NONE_SHOWN: Byte = 0
+
+    @JvmSynthetic
+    public operator fun invoke(
         op1: Boolean,
         op2: Boolean,
         op3: Boolean,
         op4: Boolean,
         op5: Boolean,
-    ) : this(
+    ): Byte = ofOps(op1, op2, op3, op4, op5)
+
+    /**
+     * Returns the bitpacked op flag out of the provided booleans.
+     */
+    @JvmStatic
+    public fun ofOps(
+        op1: Boolean,
+        op2: Boolean,
+        op3: Boolean,
+        op4: Boolean,
+        op5: Boolean,
+    ): Byte =
         toInt(op1)
             .or(toInt(op2) shl 1)
             .or(toInt(op3) shl 2)
             .or(toInt(op4) shl 3)
             .or(toInt(op5) shl 4)
-            .toByte(),
-    )
-
-    public val value: Int
-        get() = packed.toInt()
+            .toByte()
 
     /**
-     * Checks if an option is enabled.
-     * @param op the id of the option, in range of 1 to 5 (inclusive).
-     * @return whether the given option is enabled.
-     * @throws IllegalArgumentException if the option is out of bounds (not in range of 1..5)
+     * Turns the boolean to an integer.
+     * @return 1 if the boolean is enabled, 0 otherwise.
      */
-    public fun isEnabled(op: Int): Boolean {
-        require(op in 1..5) {
-            "Unexpected op value: $op"
-        }
-        val index = op - 1
-        val flag = 1 shl index
-        return packed.toInt() and flag != 0
-    }
-
-    override fun toString(): String =
-        "OpFlags(" +
-            "op1=${isEnabled(1)}, " +
-            "op2=${isEnabled(2)}, " +
-            "op3=${isEnabled(3)}, " +
-            "op4=${isEnabled(4)}, " +
-            "op5=${isEnabled(5)}" +
-            ")"
-
-    public companion object {
-        /**
-         * A constant flag for 'show all options' on an entity.
-         */
-        public val ALL_SHOWN: OpFlags = OpFlags(-1)
-
-        /**
-         * A constant flag for 'show no options' on an entity.
-         */
-        public val NONE_SHOWN: OpFlags = OpFlags(0)
-
-        /**
-         * Turns the boolean to an integer.
-         * @return 1 if the boolean is enabled, 0 otherwise.
-         */
-        private fun toInt(value: Boolean): Int = if (value) 1 else 0
-    }
+    private fun toInt(value: Boolean): Int = if (value) 1 else 0
 }

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/LocAddChange.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/LocAddChange.kt
@@ -3,7 +3,6 @@ package net.rsprot.protocol.game.outgoing.zone.payload
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.common.game.outgoing.codec.zone.payload.OldSchoolZoneProt
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
-import net.rsprot.protocol.game.outgoing.util.OpFlags
 import net.rsprot.protocol.game.outgoing.zone.payload.util.CoordInZone
 import net.rsprot.protocol.game.outgoing.zone.payload.util.LocProperties
 import net.rsprot.protocol.message.ZoneProt
@@ -21,12 +20,14 @@ import net.rsprot.protocol.message.ZoneProt
  * @property shape the shape of the loc, a value of 0 to 22 (inclusive) is expected.
  * @property rotation the rotation of the loc, a value of 0 to 3 (inclusive) is expected.
  * @property opFlags the right-click options enabled on this loc.
+ * Use the [net.rsprot.protocol.game.outgoing.util.OpFlags] helper object to create these
+ * bitpacked values which can be passed into it.
  */
 public class LocAddChange private constructor(
     private val _id: UShort,
     private val coordInZone: CoordInZone,
     private val locProperties: LocProperties,
-    public val opFlags: OpFlags,
+    public val opFlags: Byte,
 ) : ZoneProt {
     public constructor(
         id: Int,
@@ -34,7 +35,7 @@ public class LocAddChange private constructor(
         zInZone: Int,
         shape: Int,
         rotation: Int,
-        opFlags: OpFlags,
+        opFlags: Byte,
     ) : this(
         id.toUShort(),
         CoordInZone(xInZone, zInZone),

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/ObjAdd.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/ObjAdd.kt
@@ -3,7 +3,6 @@ package net.rsprot.protocol.game.outgoing.zone.payload
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.common.game.outgoing.codec.zone.payload.OldSchoolZoneProt
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
-import net.rsprot.protocol.game.outgoing.util.OpFlags
 import net.rsprot.protocol.game.outgoing.zone.payload.util.CoordInZone
 import net.rsprot.protocol.message.ZoneProt
 
@@ -27,6 +26,8 @@ import net.rsprot.protocol.message.ZoneProt
  * @property zInZone the z coordinate of the obj within the zone it is in,
  * a value in range of 0 to 7 (inclusive) is expected. Any bits outside that are ignored.
  * @property opFlags the right-click options enabled on this obj.
+ * Use the [net.rsprot.protocol.game.outgoing.util.OpFlags] helper object to create these
+ * bitpacked values which can be passed into it.
  * @property timeUntilPublic how many game cycles until the obj turns public.
  * This property is only used on the C++-based clients.
  * @property timeUntilDespawn how many game cycles until the obj disappears.
@@ -41,7 +42,7 @@ public class ObjAdd private constructor(
     private val _id: UShort,
     public val quantity: Int,
     private val coordInZone: CoordInZone,
-    public val opFlags: OpFlags,
+    public val opFlags: Byte,
     private val _timeUntilPublic: UShort,
     private val _timeUntilDespawn: UShort,
     private val _ownershipType: UByte,
@@ -52,7 +53,7 @@ public class ObjAdd private constructor(
         quantity: Int,
         xInZone: Int,
         zInZone: Int,
-        opFlags: OpFlags,
+        opFlags: Byte,
         timeUntilPublic: Int,
         timeUntilDespawn: Int,
         ownershipType: Int,
@@ -78,7 +79,7 @@ public class ObjAdd private constructor(
         quantity: Int,
         xInZone: Int,
         zInZone: Int,
-        opFlags: OpFlags,
+        opFlags: Byte,
     ) : this(
         id,
         quantity,

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/ObjOpFilter.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/ObjOpFilter.kt
@@ -3,7 +3,6 @@ package net.rsprot.protocol.game.outgoing.zone.payload
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.common.game.outgoing.codec.zone.payload.OldSchoolZoneProt
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
-import net.rsprot.protocol.game.outgoing.util.OpFlags
 import net.rsprot.protocol.game.outgoing.zone.payload.util.CoordInZone
 import net.rsprot.protocol.message.ZoneProt
 
@@ -13,7 +12,9 @@ import net.rsprot.protocol.message.ZoneProt
  * It works by finding the first obj in the stack with the provided [id],
  * and modifying the right-click ops on that. It does not verify quantity.
  * @property id the id of the obj that needs to get its ops changed
- * @property opFlags the right-click options to set enabled on that obj
+ * @property opFlags the right-click options to set enabled on that obj.
+ * Use the [net.rsprot.protocol.game.outgoing.util.OpFlags] helper object to create these
+ * bitpacked values which can be passed into it.
  * @property xInZone the x coordinate of the obj within the zone it is in,
  * a value in range of 0 to 7 (inclusive) is expected. Any bits outside that are ignored.
  * @property zInZone the z coordinate of the obj within the zone it is in,
@@ -21,12 +22,12 @@ import net.rsprot.protocol.message.ZoneProt
  */
 public class ObjOpFilter private constructor(
     private val _id: UShort,
-    public val opFlags: OpFlags,
+    public val opFlags: Byte,
     private val coordInZone: CoordInZone,
 ) : ZoneProt {
     public constructor(
         id: Int,
-        opFlags: OpFlags,
+        opFlags: Byte,
         xInZone: Int,
         zInZone: Int,
     ) : this(

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/pow/challenges/sha256/DefaultSha256ProofOfWorkProvider.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/pow/challenges/sha256/DefaultSha256ProofOfWorkProvider.kt
@@ -4,12 +4,11 @@ import net.rsprot.protocol.loginprot.incoming.pow.ProofOfWorkProvider
 import net.rsprot.protocol.loginprot.incoming.pow.SingleTypeProofOfWorkProvider
 
 /**
- * A value class to wrap the properties of a SHA-256 into a single instance.
+ * A class to wrap the properties of a SHA-256 into a single instance.
  * @property provider the SHA-256 proof of work provider.
  */
 @Suppress("MemberVisibilityCanBePrivate")
-@JvmInline
-public value class DefaultSha256ProofOfWorkProvider private constructor(
+public class DefaultSha256ProofOfWorkProvider private constructor(
     public val provider: SingleTypeProofOfWorkProvider<Sha256Challenge, Sha256MetaData>,
 ) : ProofOfWorkProvider<Sha256Challenge, Sha256MetaData> by provider {
     public constructor(

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/Password.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/Password.kt
@@ -1,12 +1,11 @@
 package net.rsprot.protocol.loginprot.incoming.util
 
 /**
- * A value class to hold the password.
+ * A class to hold the password.
  * This class offers additional functionality to clear the data from memory,
  * to avoid any potential memory attacks.
  */
-@JvmInline
-public value class Password(
+public class Password(
     public val data: ByteArray,
 ) {
     /**

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/Token.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/Token.kt
@@ -1,12 +1,11 @@
 package net.rsprot.protocol.loginprot.incoming.util
 
 /**
- * A value class to hold the login token.
+ * A class to hold the login token.
  * This class offers additional functionality to clear the data from memory,
  * to avoid any potential memory attacks.
  */
-@JvmInline
-public value class Token(
+public class Token(
     public val data: ByteArray,
 ) {
     /**

--- a/protocol/osrs-223/osrs-223-common/src/main/kotlin/net/rsprot/protocol/common/game/outgoing/inv/InventoryObject.kt
+++ b/protocol/osrs-223/osrs-223-common/src/main/kotlin/net/rsprot/protocol/common/game/outgoing/inv/InventoryObject.kt
@@ -1,63 +1,50 @@
 package net.rsprot.protocol.common.game.outgoing.inv
 
 /**
- * Inventory objects are a value class around the primitive 'long'
- * to efficiently compress an inventory's contents into a long array.
- * This allows us to avoid any garbage creation that would otherwise
- * be created by making lists of objs repeatedly.
+ * Inventory object is a helper object built around the primitive 'long' type.
+ * We utilize longs directly here to reduce the effects of garbage creation
+ * via inventories, as this can otherwise get quite severe with a lot of players.
  */
-@JvmInline
-public value class InventoryObject(
-    public val packed: Long,
-) {
-    public constructor(
+public object InventoryObject {
+    public const val NULL: Long = -1
+
+    @JvmSynthetic
+    public operator fun invoke(
         slot: Int,
         id: Int,
         count: Int,
-    ) : this(
-        (slot.toLong() and 0xFFFF)
-            .or((id.toLong() and 0xFFFF) shl 16)
-            .or((count.toLong() and 0xFFFFFFFF) shl 32),
-    )
+    ): Long = pack(slot, id, count)
 
-    public constructor(
+    @JvmStatic
+    public fun pack(
+        slot: Int,
         id: Int,
         count: Int,
-    ) : this(
-        0,
-        id,
-        count,
-    )
+    ): Long =
+        (slot.toLong() and 0xFFFF)
+            .or((id.toLong() and 0xFFFF) shl 16)
+            .or((count.toLong() and 0xFFFFFFFF) shl 32)
 
-    public val slot: Int
-        get() {
-            val value = (packed and 0xFFFF).toInt()
-            return if (value == 0xFFFF) {
-                -1
-            } else {
-                value
-            }
+    @JvmStatic
+    public fun getSlot(packed: Long): Int {
+        val value = (packed and 0xFFFF).toInt()
+        return if (value == 0xFFFF) {
+            -1
+        } else {
+            value
         }
-    public val id: Int
-        get() {
-            val value = (packed ushr 16 and 0xFFFF).toInt()
-            return if (value == 0xFFFF) {
-                -1
-            } else {
-                value
-            }
-        }
-    public val count: Int
-        get() = (packed ushr 32).toInt()
-
-    override fun toString(): String =
-        "InventoryObject(" +
-            "slot=$slot, " +
-            "id=$id, " +
-            "count=$count" +
-            ")"
-
-    public companion object {
-        public val NULL: InventoryObject = InventoryObject(-1)
     }
+
+    @JvmStatic
+    public fun getId(packed: Long): Int {
+        val value = (packed ushr 16 and 0xFFFF).toInt()
+        return if (value == 0xFFFF) {
+            -1
+        } else {
+            value
+        }
+    }
+
+    @JvmStatic
+    public fun getCount(packed: Long): Int = (packed ushr 32).toInt()
 }

--- a/protocol/osrs-223/osrs-223-desktop/src/main/kotlin/net/rsprot/protocol/game/incoming/codec/events/EventMouseMoveDecoder.kt
+++ b/protocol/osrs-223/osrs-223-desktop/src/main/kotlin/net/rsprot/protocol/game/incoming/codec/events/EventMouseMoveDecoder.kt
@@ -50,12 +50,12 @@ public class EventMouseMoveDecoder : MessageDecoder<EventMouseMove> {
                 deltaY = (packed and 0x3F) - 32
             }
             val change =
-                MouseMovements.MousePosChange(
+                MouseMovements.MousePosChange.pack(
                     timeSinceLastMovement,
                     deltaX,
                     deltaY,
                 )
-            array[count++] = change.packed
+            array[count++] = change
         }
         val slice = array.copyOf(count)
         return EventMouseMove(

--- a/protocol/osrs-223/osrs-223-desktop/src/main/kotlin/net/rsprot/protocol/game/incoming/codec/events/EventNativeMouseMoveDecoder.kt
+++ b/protocol/osrs-223/osrs-223-desktop/src/main/kotlin/net/rsprot/protocol/game/incoming/codec/events/EventNativeMouseMoveDecoder.kt
@@ -50,12 +50,12 @@ public class EventNativeMouseMoveDecoder : MessageDecoder<EventNativeMouseMove> 
                 deltaY = (packed and 0x3F) - 32
             }
             val change =
-                MouseMovements.MousePosChange(
+                MouseMovements.MousePosChange.pack(
                     timeSinceLastMovement,
                     deltaX,
                     deltaY,
                 )
-            array[count++] = change.packed
+            array[count++] = change
         }
         val slice = array.copyOf(count)
         return EventNativeMouseMove(

--- a/protocol/osrs-223/osrs-223-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/inv/UpdateInvFullEncoder.kt
+++ b/protocol/osrs-223/osrs-223-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/inv/UpdateInvFullEncoder.kt
@@ -28,12 +28,12 @@ public class UpdateInvFullEncoder : MessageEncoder<UpdateInvFull> {
                 buffer.p2(0)
                 continue
             }
-            val count = obj.count
+            val count = InventoryObject.getCount(obj)
             buffer.p1Alt2(count.coerceAtMost(0xFF))
             if (count >= 255) {
                 buffer.p4Alt3(count)
             }
-            buffer.p2(obj.id + 1)
+            buffer.p2(InventoryObject.getId(obj) + 1)
         }
         message.returnInventory()
     }

--- a/protocol/osrs-223/osrs-223-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/inv/UpdateInvPartialEncoder.kt
+++ b/protocol/osrs-223/osrs-223-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/inv/UpdateInvPartialEncoder.kt
@@ -3,6 +3,7 @@ package net.rsprot.protocol.game.outgoing.codec.inv
 import net.rsprot.buffer.JagByteBuf
 import net.rsprot.crypto.cipher.StreamCipher
 import net.rsprot.protocol.ServerProt
+import net.rsprot.protocol.common.game.outgoing.inv.InventoryObject
 import net.rsprot.protocol.game.outgoing.inv.UpdateInvPartial
 import net.rsprot.protocol.game.outgoing.prot.GameServerProt
 import net.rsprot.protocol.message.codec.MessageEncoder
@@ -22,14 +23,14 @@ public class UpdateInvPartialEncoder : MessageEncoder<UpdateInvPartial> {
         buffer.p2(message.inventoryId)
         for (i in 0..<message.count) {
             val obj = message.getObject(i)
-            buffer.pSmart1or2(obj.slot)
-            val id = obj.id
+            buffer.pSmart1or2(InventoryObject.getSlot(obj))
+            val id = InventoryObject.getId(obj)
             if (id == -1) {
                 buffer.p2(0)
                 continue
             }
             buffer.p2(id + 1)
-            val count = obj.count
+            val count = InventoryObject.getCount(obj)
             buffer.p1(count.coerceAtMost(0xFF))
             if (count >= 0xFF) {
                 buffer.p4(count)

--- a/protocol/osrs-223/osrs-223-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/LocAddChangeEncoder.kt
+++ b/protocol/osrs-223/osrs-223-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/LocAddChangeEncoder.kt
@@ -17,7 +17,7 @@ public class LocAddChangeEncoder : ZoneProtEncoder<LocAddChange> {
         // making it easy to identify all the properties of this packet:
         // loc_add_change_del(world, level, x, z, layer, id, shape, rotation, opFlags, 0, -1)
         buffer.p1Alt2(message.locPropertiesPacked)
-        buffer.p1Alt3(message.opFlags.value)
+        buffer.p1Alt3(message.opFlags.toInt())
         buffer.p1Alt3(message.coordInZonePacked)
         buffer.p2Alt2(message.id)
     }

--- a/protocol/osrs-223/osrs-223-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/ObjAddEncoder.kt
+++ b/protocol/osrs-223/osrs-223-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/ObjAddEncoder.kt
@@ -20,7 +20,7 @@ public class ObjAddEncoder : ZoneProtEncoder<ObjAdd> {
         buffer.p2Alt1(message.timeUntilDespawn)
         buffer.p1Alt3(if (message.neverBecomesPublic) 1 else 0)
         buffer.p2Alt2(message.id)
-        buffer.p1Alt1(message.opFlags.value)
+        buffer.p1Alt1(message.opFlags.toInt())
         buffer.p1Alt1(message.ownershipType)
         buffer.p2(message.timeUntilPublic)
         buffer.p4Alt3(message.quantity)

--- a/protocol/osrs-223/osrs-223-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/ObjEnabledOpsEncoder.kt
+++ b/protocol/osrs-223/osrs-223-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/ObjEnabledOpsEncoder.kt
@@ -16,7 +16,7 @@ public class ObjEnabledOpsEncoder : ZoneProtEncoder<ObjEnabledOps> {
         // The function at the bottom of the OBJ_OPFILTER has a consistent order,
         // making it easy to identify all the properties of this packet:
         // obj_opfilter(level, x, z, id, opFlags)
-        buffer.p1Alt2(message.opFlags.value)
+        buffer.p1Alt2(message.opFlags.toInt())
         buffer.p1Alt2(message.coordInZonePacked)
         buffer.p2(message.id)
     }

--- a/protocol/osrs-223/osrs-223-internal/src/main/kotlin/net/rsprot/protocol/common/game/outgoing/inv/internal/Inventory.kt
+++ b/protocol/osrs-223/osrs-223-internal/src/main/kotlin/net/rsprot/protocol/common/game/outgoing/inv/internal/Inventory.kt
@@ -37,8 +37,8 @@ public class Inventory private constructor(
      * @throws ArrayIndexOutOfBoundsException if the inventory is full
      */
     @Throws(ArrayIndexOutOfBoundsException::class)
-    public fun add(obj: InventoryObject) {
-        contents[count++] = obj.packed
+    public fun add(obj: Long) {
+        contents[count++] = obj
     }
 
     /**
@@ -48,7 +48,7 @@ public class Inventory private constructor(
      * @throws ArrayIndexOutOfBoundsException if the index is out of bounds
      */
     @Throws(ArrayIndexOutOfBoundsException::class)
-    public operator fun get(slot: Int): InventoryObject = InventoryObject(contents[slot])
+    public operator fun get(slot: Int): Long = contents[slot]
 
     /**
      * Clears the inventory by setting the count to zero.

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/incoming/events/EventKeyboard.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/incoming/events/EventKeyboard.kt
@@ -55,8 +55,7 @@ public class EventKeyboard(
      * format back into the normalized [java.awt.event.KeyEvent] format.
      * @property length the length of the key sequence
      */
-    @JvmInline
-    public value class KeySequence(
+    public class KeySequence(
         private val array: ByteArray,
     ) {
         public val length: Int

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/incoming/events/util/MouseMovements.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/incoming/events/util/MouseMovements.kt
@@ -1,13 +1,12 @@
 package net.rsprot.protocol.game.incoming.events.util
 
 /**
- * A value class that wraps around an array of mouse movements,
+ * A class that wraps around an array of mouse movements,
  * with the encoding specified by [MousePosChange].
  * @property length the number of mouse movements in this packet.
  */
 @Suppress("MemberVisibilityCanBePrivate")
-@JvmInline
-public value class MouseMovements(
+public class MouseMovements(
     private val movements: LongArray,
 ) {
     public val length: Int
@@ -34,7 +33,7 @@ public value class MouseMovements(
     public fun getMousePosChange(index: Int): MousePosChange = MousePosChange(movements[index])
 
     /**
-     * A value class for mouse position changes, packed into a primitive long.
+     * A class for mouse position changes, packed into a primitive long.
      * We utilize bitpacking in order to use primitive long arrays for space
      * constraints.
      * @property packed the bitpacked long value, exposed as servers may wish
@@ -47,8 +46,7 @@ public value class MouseMovements(
      * mouse goes outside the client window, the value will be -1.
      */
     @Suppress("MemberVisibilityCanBePrivate")
-    @JvmInline
-    public value class MousePosChange(
+    public class MousePosChange(
         public val packed: Long,
     ) {
         public constructor(
@@ -56,10 +54,7 @@ public value class MouseMovements(
             xDelta: Int,
             yDelta: Int,
         ) : this(
-            (timeDelta and 0xFFFF)
-                .toLong()
-                .or(xDelta.toLong() and 0xFFFF shl 16)
-                .or(yDelta.toLong() and 0xFFFF shl 32),
+            pack(timeDelta, xDelta, yDelta),
         )
 
         public val timeDelta: Int
@@ -75,5 +70,17 @@ public value class MouseMovements(
                 "xDelta=$xDelta, " +
                 "yDelta=$yDelta" +
                 ")"
+
+        public companion object {
+            public fun pack(
+                timeDelta: Int,
+                xDelta: Int,
+                yDelta: Int,
+            ): Long =
+                (timeDelta and 0xFFFF)
+                    .toLong()
+                    .or(xDelta.toLong() and 0xFFFF shl 16)
+                    .or(yDelta.toLong() and 0xFFFF shl 32)
+        }
     }
 }

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/incoming/messaging/MessagePublic.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/incoming/messaging/MessagePublic.kt
@@ -141,14 +141,13 @@ public class MessagePublic private constructor(
             ")"
 
     /**
-     * A value class for message colour patterns, allowing easy
+     * A class for message colour patterns, allowing easy
      * conversion from the byte array to the respective 24-bit RGB colours.
      * This wrapper class additionally provides a helpful [isValid] function,
      * as it is possible to otherwise send bad data from the client and
      * crash the players in vicinity.
      */
-    @JvmInline
-    public value class MessageColourPattern(
+    public class MessageColourPattern(
         private val bytes: ByteArray,
     ) {
         public val length: Int

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfo.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfo.kt
@@ -89,6 +89,32 @@ public class NpcInfo internal constructor(
     }
 
     /**
+     * Updates the build area of a given world to the specified one.
+     * This will ensure that no NPCs outside of this box will be
+     * added to high resolution view.
+     * @param worldId the id of the world to set the build area of,
+     * with -1 being the root world.
+     * @param zoneX the south-western zone x coordinate of the build area
+     * @param zoneZ the south-western zone z coordinate of the build area
+     * @param widthInZones the build area width in zones (typically 13, meaning 104 tiles)
+     * @param heightInZones the build area height in zones (typically 13, meaning 104 tiles)
+     */
+    @JvmOverloads
+    public fun updateBuildArea(
+        worldId: Int,
+        zoneX: Int,
+        zoneZ: Int,
+        widthInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+        heightInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+    ) {
+        require(worldId == ROOT_WORLD || worldId in 0..<2048) {
+            "World id must be -1 or in range of 0..<2048"
+        }
+        val details = getDetails(worldId)
+        details.buildArea = BuildArea(zoneX, zoneZ, widthInZones, heightInZones)
+    }
+
+    /**
      * Allocates a new NPC info tracking object for the respective [worldId],
      * keeping track of everyone that's within this new world entity.
      * @param worldId the new world entity id

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
@@ -176,6 +176,32 @@ public class PlayerInfo internal constructor(
     }
 
     /**
+     * Updates the build area of a given world to the specified one.
+     * This will ensure that no players outside of this box will be
+     * added to high resolution view.
+     * @param worldId the id of the world to set the build area of,
+     * with -1 being the root world.
+     * @param zoneX the south-western zone x coordinate of the build area
+     * @param zoneZ the south-western zone z coordinate of the build area
+     * @param widthInZones the build area width in zones (typically 13, meaning 104 tiles)
+     * @param heightInZones the build area height in zones (typically 13, meaning 104 tiles)
+     */
+    @JvmOverloads
+    public fun updateBuildArea(
+        worldId: Int,
+        zoneX: Int,
+        zoneZ: Int,
+        widthInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+        heightInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+    ) {
+        require(worldId == ROOT_WORLD || worldId in 0..<2048) {
+            "World id must be -1 or in range of 0..<2048"
+        }
+        val details = getDetails(worldId)
+        details.buildArea = BuildArea(zoneX, zoneZ, widthInZones, heightInZones)
+    }
+
+    /**
      * Allocates a new player info tracking object for the respective [worldId],
      * keeping track of everyone that's within this new world entity.
      * @param worldId the new world entity id

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityInfo.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityInfo.kt
@@ -113,6 +113,24 @@ public class WorldEntityInfo internal constructor(
     }
 
     /**
+     * Updates the build area for this player. This should always perfectly correspond to
+     * the actual build area that is sent via REBUILD_NORMAL or REBUILD_REGION packets.
+     * @property zoneX the south-western zone x coordinate of the build area
+     * @property zoneZ the south-western zone z coordinate of the build area
+     * @property widthInZones the build area width in zones (typically 13, meaning 104 tiles)
+     * @property heightInZones the build area height in zones (typically 13, meaning 104 tiles)
+     */
+    @JvmOverloads
+    public fun updateBuildArea(
+        zoneX: Int,
+        zoneZ: Int,
+        widthInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+        heightInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+    ) {
+        this.buildArea = BuildArea(zoneX, zoneZ, widthInZones, heightInZones)
+    }
+
+    /**
      * Gets a list of all the world entity indices that are currently in high resolution,
      * allowing for correct functionality for player and npc infos, as well as zone updates.
      * @return a list of indices of the world entities currently in high resolution.

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/inv/UpdateInvFull.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/inv/UpdateInvFull.kt
@@ -90,14 +90,14 @@ public class UpdateInvFull private constructor(
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
 
     /**
-     * Gets the obj in the [slot] provided.
+     * Gets the bitpacked obj in the [slot] provided.
      * @param slot the slot in the inventory.
      * @return the inventory object that's in that slot,
      * or [InventoryObject.NULL] if there's no object.
      * @throws IndexOutOfBoundsException if the [slot] is outside
      * the inventory's boundaries.
      */
-    public fun getObject(slot: Int): InventoryObject = inventory[slot]
+    public fun getObject(slot: Int): Long = inventory[slot]
 
     public fun returnInventory() {
         inventory.clear()
@@ -141,11 +141,11 @@ public class UpdateInvFull private constructor(
      */
     public fun interface ObjectProvider {
         /**
-         * Provides an [InventoryObject] instance for a given slot
+         * Provides an [InventoryObject] for a given slot
          * in inventory. If there is no object in that slot,
          * use [InventoryObject.NULL] as an indicator of it.
          */
-        public fun provide(slot: Int): InventoryObject
+        public fun provide(slot: Int): Long
     }
 
     private companion object {
@@ -156,7 +156,7 @@ public class UpdateInvFull private constructor(
          * @param provider the object provider, used to return information
          * about an object in a slot of an inventory.
          * @return an inventory object, which is a compressed representation
-         * of a list of [InventoryObject]s, backed by a long array.
+         * of a list of [InventoryObject]s as longs, backed by a long array.
          */
         private fun buildInventory(
             capacity: Int,
@@ -166,7 +166,7 @@ public class UpdateInvFull private constructor(
             for (i in 0..<capacity) {
                 val obj = provider.provide(i)
                 if (RSProtFlags.inventoryObjCheck) {
-                    check(obj == InventoryObject.NULL || obj.count >= 0) {
+                    check(obj == InventoryObject.NULL || InventoryObject.getCount(obj) >= 0) {
                         "Obj count cannot be below zero: $obj @ $i"
                     }
                 }

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/inv/UpdateInvPartial.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/inv/UpdateInvPartial.kt
@@ -106,14 +106,14 @@ public class UpdateInvPartial private constructor(
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
 
     /**
-     * Gets the obj in the [slot] provided.
+     * Gets the bitpacked obj in the [slot] provided.
      * @param slot the slot in the inventory.
      * @return the inventory object that's in that slot,
      * or [InventoryObject.NULL] if there's no object.
      * @throws IndexOutOfBoundsException if the [slot] is outside
      * the inventory's boundaries.
      */
-    public fun getObject(slot: Int): InventoryObject = inventory[slot]
+    public fun getObject(slot: Int): Long = inventory[slot]
 
     public fun returnInventory() {
         inventory.clear()
@@ -159,11 +159,11 @@ public class UpdateInvPartial private constructor(
         internal val indices: Iterator<Int>,
     ) {
         /**
-         * Provides an [InventoryObject] instance for a given slot
+         * Provides an [InventoryObject] for a given slot
          * in inventory. If there is no object in that slot,
          * use [InventoryObject.NULL] as an indicator of it.
          */
-        public abstract fun provide(slot: Int): InventoryObject
+        public abstract fun provide(slot: Int): Long
     }
 
     private companion object {
@@ -172,7 +172,7 @@ public class UpdateInvPartial private constructor(
          * @param provider the object provider, used to return information
          * about an object in a slot of an inventory.
          * @return an inventory object, which is a compressed representation
-         * of a list of [InventoryObject]s, backed by a long array.
+         * of a list of [InventoryObject]s as longs, backed by a long array.
          */
         private fun buildInventory(provider: IndexedObjectProvider): Inventory {
             val inventory = InventoryPool.pool.borrowObject()
@@ -183,10 +183,10 @@ public class UpdateInvPartial private constructor(
                         "Obj cannot be InventoryObject.NULL for partial updates. Use InventoryObject(slot, -1, -1) " +
                             "instead."
                     }
-                    check(obj.slot >= 0) {
+                    check(InventoryObject.getSlot(obj) >= 0) {
                         "Obj slot cannot be below zero: $obj $ $index"
                     }
-                    check(obj.id == -1 || obj.count >= 0) {
+                    check(InventoryObject.getId(obj) == -1 || InventoryObject.getCount(obj) >= 0) {
                         "Obj count cannot be below zero: $obj @ $index"
                     }
                 }

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/util/RebuildRegionZone.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/util/RebuildRegionZone.kt
@@ -28,6 +28,15 @@ public class RebuildRegionZone private constructor(
         key,
     )
 
+    public val rotation: Int
+        get() = referenceZone.rotation
+    public val zoneX: Int
+        get() = referenceZone.zoneX
+    public val zoneZ: Int
+        get() = referenceZone.zoneZ
+    public val level: Int
+        get() = referenceZone.level
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/util/OpFlags.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/util/OpFlags.kt
@@ -3,70 +3,50 @@ package net.rsprot.protocol.game.outgoing.util
 /**
  * Op flags are used to hide or show certain right-click options on various
  * interactable entities.
- * This is a helper class to create
+ * This is a helper class to create various combinations of this flag.
  */
 @Suppress("MemberVisibilityCanBePrivate")
-@JvmInline
-public value class OpFlags(
-    private val packed: Byte,
-) {
-    public constructor(
+public object OpFlags {
+    /**
+     * A constant flag for 'show all options' on an entity.
+     */
+    public const val ALL_SHOWN: Byte = -1
+
+    /**
+     * A constant flag for 'show no options' on an entity.
+     */
+    public const val NONE_SHOWN: Byte = 0
+
+    @JvmSynthetic
+    public operator fun invoke(
         op1: Boolean,
         op2: Boolean,
         op3: Boolean,
         op4: Boolean,
         op5: Boolean,
-    ) : this(
+    ): Byte = ofOps(op1, op2, op3, op4, op5)
+
+    /**
+     * Returns the bitpacked op flag out of the provided booleans.
+     */
+    @JvmStatic
+    public fun ofOps(
+        op1: Boolean,
+        op2: Boolean,
+        op3: Boolean,
+        op4: Boolean,
+        op5: Boolean,
+    ): Byte =
         toInt(op1)
             .or(toInt(op2) shl 1)
             .or(toInt(op3) shl 2)
             .or(toInt(op4) shl 3)
             .or(toInt(op5) shl 4)
-            .toByte(),
-    )
-
-    public val value: Int
-        get() = packed.toInt()
+            .toByte()
 
     /**
-     * Checks if an option is enabled.
-     * @param op the id of the option, in range of 1 to 5 (inclusive).
-     * @return whether the given option is enabled.
-     * @throws IllegalArgumentException if the option is out of bounds (not in range of 1..5)
+     * Turns the boolean to an integer.
+     * @return 1 if the boolean is enabled, 0 otherwise.
      */
-    public fun isEnabled(op: Int): Boolean {
-        require(op in 1..5) {
-            "Unexpected op value: $op"
-        }
-        val index = op - 1
-        val flag = 1 shl index
-        return packed.toInt() and flag != 0
-    }
-
-    override fun toString(): String =
-        "OpFlags(" +
-            "op1=${isEnabled(1)}, " +
-            "op2=${isEnabled(2)}, " +
-            "op3=${isEnabled(3)}, " +
-            "op4=${isEnabled(4)}, " +
-            "op5=${isEnabled(5)}" +
-            ")"
-
-    public companion object {
-        /**
-         * A constant flag for 'show all options' on an entity.
-         */
-        public val ALL_SHOWN: OpFlags = OpFlags(-1)
-
-        /**
-         * A constant flag for 'show no options' on an entity.
-         */
-        public val NONE_SHOWN: OpFlags = OpFlags(0)
-
-        /**
-         * Turns the boolean to an integer.
-         * @return 1 if the boolean is enabled, 0 otherwise.
-         */
-        private fun toInt(value: Boolean): Int = if (value) 1 else 0
-    }
+    private fun toInt(value: Boolean): Int = if (value) 1 else 0
 }

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/LocAddChange.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/LocAddChange.kt
@@ -3,7 +3,6 @@ package net.rsprot.protocol.game.outgoing.zone.payload
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.common.game.outgoing.codec.zone.payload.OldSchoolZoneProt
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
-import net.rsprot.protocol.game.outgoing.util.OpFlags
 import net.rsprot.protocol.game.outgoing.zone.payload.util.CoordInZone
 import net.rsprot.protocol.game.outgoing.zone.payload.util.LocProperties
 import net.rsprot.protocol.message.ZoneProt
@@ -21,12 +20,14 @@ import net.rsprot.protocol.message.ZoneProt
  * @property shape the shape of the loc, a value of 0 to 22 (inclusive) is expected.
  * @property rotation the rotation of the loc, a value of 0 to 3 (inclusive) is expected.
  * @property opFlags the right-click options enabled on this loc.
+ * Use the [net.rsprot.protocol.game.outgoing.util.OpFlags] helper object to create these
+ * bitpacked values which can be passed into it.
  */
 public class LocAddChange private constructor(
     private val _id: UShort,
     private val coordInZone: CoordInZone,
     private val locProperties: LocProperties,
-    public val opFlags: OpFlags,
+    public val opFlags: Byte,
 ) : ZoneProt {
     public constructor(
         id: Int,
@@ -34,7 +35,7 @@ public class LocAddChange private constructor(
         zInZone: Int,
         shape: Int,
         rotation: Int,
-        opFlags: OpFlags,
+        opFlags: Byte,
     ) : this(
         id.toUShort(),
         CoordInZone(xInZone, zInZone),

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/ObjAdd.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/ObjAdd.kt
@@ -3,7 +3,6 @@ package net.rsprot.protocol.game.outgoing.zone.payload
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.common.game.outgoing.codec.zone.payload.OldSchoolZoneProt
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
-import net.rsprot.protocol.game.outgoing.util.OpFlags
 import net.rsprot.protocol.game.outgoing.zone.payload.util.CoordInZone
 import net.rsprot.protocol.message.ZoneProt
 
@@ -27,6 +26,8 @@ import net.rsprot.protocol.message.ZoneProt
  * @property zInZone the z coordinate of the obj within the zone it is in,
  * a value in range of 0 to 7 (inclusive) is expected. Any bits outside that are ignored.
  * @property opFlags the right-click options enabled on this obj.
+ * Use the [net.rsprot.protocol.game.outgoing.util.OpFlags] helper object to create these
+ * bitpacked values which can be passed into it.
  * @property timeUntilPublic how many game cycles until the obj turns public.
  * This property is only used on the C++-based clients.
  * @property timeUntilDespawn how many game cycles until the obj disappears.
@@ -41,7 +42,7 @@ public class ObjAdd private constructor(
     private val _id: UShort,
     public val quantity: Int,
     private val coordInZone: CoordInZone,
-    public val opFlags: OpFlags,
+    public val opFlags: Byte,
     private val _timeUntilPublic: UShort,
     private val _timeUntilDespawn: UShort,
     private val _ownershipType: UByte,
@@ -52,7 +53,7 @@ public class ObjAdd private constructor(
         quantity: Int,
         xInZone: Int,
         zInZone: Int,
-        opFlags: OpFlags,
+        opFlags: Byte,
         timeUntilPublic: Int,
         timeUntilDespawn: Int,
         ownershipType: Int,
@@ -78,7 +79,7 @@ public class ObjAdd private constructor(
         quantity: Int,
         xInZone: Int,
         zInZone: Int,
-        opFlags: OpFlags,
+        opFlags: Byte,
     ) : this(
         id,
         quantity,

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/ObjEnabledOps.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/ObjEnabledOps.kt
@@ -3,7 +3,6 @@ package net.rsprot.protocol.game.outgoing.zone.payload
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.common.game.outgoing.codec.zone.payload.OldSchoolZoneProt
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
-import net.rsprot.protocol.game.outgoing.util.OpFlags
 import net.rsprot.protocol.game.outgoing.zone.payload.util.CoordInZone
 import net.rsprot.protocol.message.ZoneProt
 
@@ -13,7 +12,9 @@ import net.rsprot.protocol.message.ZoneProt
  * It works by finding the first obj in the stack with the provided [id],
  * and modifying the right-click ops on that. It does not verify quantity.
  * @property id the id of the obj that needs to get its ops changed
- * @property opFlags the right-click options to set enabled on that obj
+ * @property opFlags the right-click options to set enabled on that obj.
+ * Use the [net.rsprot.protocol.game.outgoing.util.OpFlags] helper object to create these
+ * bitpacked values which can be passed into it.
  * @property xInZone the x coordinate of the obj within the zone it is in,
  * a value in range of 0 to 7 (inclusive) is expected. Any bits outside that are ignored.
  * @property zInZone the z coordinate of the obj within the zone it is in,
@@ -21,12 +22,12 @@ import net.rsprot.protocol.message.ZoneProt
  */
 public class ObjEnabledOps private constructor(
     private val _id: UShort,
-    public val opFlags: OpFlags,
+    public val opFlags: Byte,
     private val coordInZone: CoordInZone,
 ) : ZoneProt {
     public constructor(
         id: Int,
-        opFlags: OpFlags,
+        opFlags: Byte,
         xInZone: Int,
         zInZone: Int,
     ) : this(

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/pow/challenges/sha256/DefaultSha256ProofOfWorkProvider.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/pow/challenges/sha256/DefaultSha256ProofOfWorkProvider.kt
@@ -4,12 +4,11 @@ import net.rsprot.protocol.loginprot.incoming.pow.ProofOfWorkProvider
 import net.rsprot.protocol.loginprot.incoming.pow.SingleTypeProofOfWorkProvider
 
 /**
- * A value class to wrap the properties of a SHA-256 into a single instance.
+ * A class to wrap the properties of a SHA-256 into a single instance.
  * @property provider the SHA-256 proof of work provider.
  */
 @Suppress("MemberVisibilityCanBePrivate")
-@JvmInline
-public value class DefaultSha256ProofOfWorkProvider private constructor(
+public class DefaultSha256ProofOfWorkProvider private constructor(
     public val provider: SingleTypeProofOfWorkProvider<Sha256Challenge, Sha256MetaData>,
 ) : ProofOfWorkProvider<Sha256Challenge, Sha256MetaData> by provider {
     public constructor(

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/Password.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/Password.kt
@@ -1,12 +1,11 @@
 package net.rsprot.protocol.loginprot.incoming.util
 
 /**
- * A value class to hold the password.
+ * A class to hold the password.
  * This class offers additional functionality to clear the data from memory,
  * to avoid any potential memory attacks.
  */
-@JvmInline
-public value class Password(
+public class Password(
     public val data: ByteArray,
 ) {
     /**

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/Token.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/Token.kt
@@ -1,12 +1,11 @@
 package net.rsprot.protocol.loginprot.incoming.util
 
 /**
- * A value class to hold the login token.
+ * A class to hold the login token.
  * This class offers additional functionality to clear the data from memory,
  * to avoid any potential memory attacks.
  */
-@JvmInline
-public value class Token(
+public class Token(
     public val data: ByteArray,
 ) {
     /**

--- a/protocol/osrs-224/osrs-224-common/src/main/kotlin/net/rsprot/protocol/common/game/outgoing/inv/InventoryObject.kt
+++ b/protocol/osrs-224/osrs-224-common/src/main/kotlin/net/rsprot/protocol/common/game/outgoing/inv/InventoryObject.kt
@@ -1,63 +1,50 @@
 package net.rsprot.protocol.common.game.outgoing.inv
 
 /**
- * Inventory objects are a value class around the primitive 'long'
- * to efficiently compress an inventory's contents into a long array.
- * This allows us to avoid any garbage creation that would otherwise
- * be created by making lists of objs repeatedly.
+ * Inventory object is a helper object built around the primitive 'long' type.
+ * We utilize longs directly here to reduce the effects of garbage creation
+ * via inventories, as this can otherwise get quite severe with a lot of players.
  */
-@JvmInline
-public value class InventoryObject(
-    public val packed: Long,
-) {
-    public constructor(
+public object InventoryObject {
+    public const val NULL: Long = -1
+
+    @JvmSynthetic
+    public operator fun invoke(
         slot: Int,
         id: Int,
         count: Int,
-    ) : this(
-        (slot.toLong() and 0xFFFF)
-            .or((id.toLong() and 0xFFFF) shl 16)
-            .or((count.toLong() and 0xFFFFFFFF) shl 32),
-    )
+    ): Long = pack(slot, id, count)
 
-    public constructor(
+    @JvmStatic
+    public fun pack(
+        slot: Int,
         id: Int,
         count: Int,
-    ) : this(
-        0,
-        id,
-        count,
-    )
+    ): Long =
+        (slot.toLong() and 0xFFFF)
+            .or((id.toLong() and 0xFFFF) shl 16)
+            .or((count.toLong() and 0xFFFFFFFF) shl 32)
 
-    public val slot: Int
-        get() {
-            val value = (packed and 0xFFFF).toInt()
-            return if (value == 0xFFFF) {
-                -1
-            } else {
-                value
-            }
+    @JvmStatic
+    public fun getSlot(packed: Long): Int {
+        val value = (packed and 0xFFFF).toInt()
+        return if (value == 0xFFFF) {
+            -1
+        } else {
+            value
         }
-    public val id: Int
-        get() {
-            val value = (packed ushr 16 and 0xFFFF).toInt()
-            return if (value == 0xFFFF) {
-                -1
-            } else {
-                value
-            }
-        }
-    public val count: Int
-        get() = (packed ushr 32).toInt()
-
-    override fun toString(): String =
-        "InventoryObject(" +
-            "slot=$slot, " +
-            "id=$id, " +
-            "count=$count" +
-            ")"
-
-    public companion object {
-        public val NULL: InventoryObject = InventoryObject(-1)
     }
+
+    @JvmStatic
+    public fun getId(packed: Long): Int {
+        val value = (packed ushr 16 and 0xFFFF).toInt()
+        return if (value == 0xFFFF) {
+            -1
+        } else {
+            value
+        }
+    }
+
+    @JvmStatic
+    public fun getCount(packed: Long): Int = (packed ushr 32).toInt()
 }

--- a/protocol/osrs-224/osrs-224-desktop/src/main/kotlin/net/rsprot/protocol/game/incoming/codec/events/EventMouseMoveDecoder.kt
+++ b/protocol/osrs-224/osrs-224-desktop/src/main/kotlin/net/rsprot/protocol/game/incoming/codec/events/EventMouseMoveDecoder.kt
@@ -50,12 +50,12 @@ public class EventMouseMoveDecoder : MessageDecoder<EventMouseMove> {
                 deltaY = (packed and 0x3F) - 32
             }
             val change =
-                MouseMovements.MousePosChange(
+                MouseMovements.MousePosChange.pack(
                     timeSinceLastMovement,
                     deltaX,
                     deltaY,
                 )
-            array[count++] = change.packed
+            array[count++] = change
         }
         val slice = array.copyOf(count)
         return EventMouseMove(

--- a/protocol/osrs-224/osrs-224-desktop/src/main/kotlin/net/rsprot/protocol/game/incoming/codec/events/EventNativeMouseMoveDecoder.kt
+++ b/protocol/osrs-224/osrs-224-desktop/src/main/kotlin/net/rsprot/protocol/game/incoming/codec/events/EventNativeMouseMoveDecoder.kt
@@ -50,12 +50,12 @@ public class EventNativeMouseMoveDecoder : MessageDecoder<EventNativeMouseMove> 
                 deltaY = (packed and 0x3F) - 32
             }
             val change =
-                MouseMovements.MousePosChange(
+                MouseMovements.MousePosChange.pack(
                     timeSinceLastMovement,
                     deltaX,
                     deltaY,
                 )
-            array[count++] = change.packed
+            array[count++] = change
         }
         val slice = array.copyOf(count)
         return EventNativeMouseMove(

--- a/protocol/osrs-224/osrs-224-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/inv/UpdateInvFullEncoder.kt
+++ b/protocol/osrs-224/osrs-224-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/inv/UpdateInvFullEncoder.kt
@@ -28,12 +28,12 @@ public class UpdateInvFullEncoder : MessageEncoder<UpdateInvFull> {
                 buffer.p2Alt1(0)
                 continue
             }
-            val count = obj.count
+            val count = InventoryObject.getCount(obj)
             buffer.p1Alt3(count.coerceAtMost(0xFF))
             if (count >= 255) {
                 buffer.p4(count)
             }
-            buffer.p2Alt1(obj.id + 1)
+            buffer.p2Alt1(InventoryObject.getId(obj) + 1)
         }
         message.returnInventory()
     }

--- a/protocol/osrs-224/osrs-224-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/inv/UpdateInvPartialEncoder.kt
+++ b/protocol/osrs-224/osrs-224-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/inv/UpdateInvPartialEncoder.kt
@@ -3,6 +3,7 @@ package net.rsprot.protocol.game.outgoing.codec.inv
 import net.rsprot.buffer.JagByteBuf
 import net.rsprot.crypto.cipher.StreamCipher
 import net.rsprot.protocol.ServerProt
+import net.rsprot.protocol.common.game.outgoing.inv.InventoryObject
 import net.rsprot.protocol.game.outgoing.inv.UpdateInvPartial
 import net.rsprot.protocol.game.outgoing.prot.GameServerProt
 import net.rsprot.protocol.message.codec.MessageEncoder
@@ -22,14 +23,14 @@ public class UpdateInvPartialEncoder : MessageEncoder<UpdateInvPartial> {
         buffer.p2(message.inventoryId)
         for (i in 0..<message.count) {
             val obj = message.getObject(i)
-            buffer.pSmart1or2(obj.slot)
-            val id = obj.id
+            buffer.pSmart1or2(InventoryObject.getSlot(obj))
+            val id = InventoryObject.getId(obj)
             if (id == -1) {
                 buffer.p2(0)
                 continue
             }
             buffer.p2(id + 1)
-            val count = obj.count
+            val count = InventoryObject.getCount(obj)
             buffer.p1(count.coerceAtMost(0xFF))
             if (count >= 0xFF) {
                 buffer.p4(count)

--- a/protocol/osrs-224/osrs-224-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/LocAddChangeEncoder.kt
+++ b/protocol/osrs-224/osrs-224-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/LocAddChangeEncoder.kt
@@ -18,7 +18,7 @@ public class LocAddChangeEncoder : ZoneProtEncoder<LocAddChange> {
         // loc_add_change_del(world, level, x, z, layer, id, shape, rotation, opFlags, 0, -1)
         buffer.p1Alt2(message.locPropertiesPacked)
         buffer.p1(message.coordInZonePacked)
-        buffer.p1Alt2(message.opFlags.value)
+        buffer.p1Alt2(message.opFlags.toInt())
         buffer.p2Alt1(message.id)
     }
 }

--- a/protocol/osrs-224/osrs-224-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/ObjAddEncoder.kt
+++ b/protocol/osrs-224/osrs-224-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/ObjAddEncoder.kt
@@ -20,7 +20,7 @@ public class ObjAddEncoder : ZoneProtEncoder<ObjAdd> {
         buffer.p2Alt3(message.id)
         buffer.p1Alt2(if (message.neverBecomesPublic) 1 else 0)
         buffer.p4Alt1(message.quantity)
-        buffer.p1Alt3(message.opFlags.value)
+        buffer.p1Alt3(message.opFlags.toInt())
         buffer.p2Alt1(message.timeUntilPublic)
         buffer.p2Alt2(message.timeUntilDespawn)
         buffer.p1Alt3(message.coordInZonePacked)

--- a/protocol/osrs-224/osrs-224-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/ObjEnabledOpsEncoder.kt
+++ b/protocol/osrs-224/osrs-224-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/ObjEnabledOpsEncoder.kt
@@ -16,7 +16,7 @@ public class ObjEnabledOpsEncoder : ZoneProtEncoder<ObjEnabledOps> {
         // The function at the bottom of the OBJ_OPFILTER has a consistent order,
         // making it easy to identify all the properties of this packet:
         // obj_opfilter(level, x, z, id, opFlags)
-        buffer.p1Alt3(message.opFlags.value)
+        buffer.p1Alt3(message.opFlags.toInt())
         buffer.p2(message.id)
         buffer.p1Alt2(message.coordInZonePacked)
     }

--- a/protocol/osrs-224/osrs-224-internal/src/main/kotlin/net/rsprot/protocol/common/game/outgoing/inv/internal/Inventory.kt
+++ b/protocol/osrs-224/osrs-224-internal/src/main/kotlin/net/rsprot/protocol/common/game/outgoing/inv/internal/Inventory.kt
@@ -37,8 +37,8 @@ public class Inventory private constructor(
      * @throws ArrayIndexOutOfBoundsException if the inventory is full
      */
     @Throws(ArrayIndexOutOfBoundsException::class)
-    public fun add(obj: InventoryObject) {
-        contents[count++] = obj.packed
+    public fun add(obj: Long) {
+        contents[count++] = obj
     }
 
     /**
@@ -48,7 +48,7 @@ public class Inventory private constructor(
      * @throws ArrayIndexOutOfBoundsException if the index is out of bounds
      */
     @Throws(ArrayIndexOutOfBoundsException::class)
-    public operator fun get(slot: Int): InventoryObject = InventoryObject(contents[slot])
+    public operator fun get(slot: Int): Long = contents[slot]
 
     /**
      * Clears the inventory by setting the count to zero.

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/incoming/events/EventKeyboard.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/incoming/events/EventKeyboard.kt
@@ -55,8 +55,7 @@ public class EventKeyboard(
      * format back into the normalized [java.awt.event.KeyEvent] format.
      * @property length the length of the key sequence
      */
-    @JvmInline
-    public value class KeySequence(
+    public class KeySequence(
         private val array: ByteArray,
     ) {
         public val length: Int

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/incoming/events/util/MouseMovements.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/incoming/events/util/MouseMovements.kt
@@ -1,13 +1,12 @@
 package net.rsprot.protocol.game.incoming.events.util
 
 /**
- * A value class that wraps around an array of mouse movements,
+ * A class that wraps around an array of mouse movements,
  * with the encoding specified by [MousePosChange].
  * @property length the number of mouse movements in this packet.
  */
 @Suppress("MemberVisibilityCanBePrivate")
-@JvmInline
-public value class MouseMovements(
+public class MouseMovements(
     private val movements: LongArray,
 ) {
     public val length: Int
@@ -34,7 +33,7 @@ public value class MouseMovements(
     public fun getMousePosChange(index: Int): MousePosChange = MousePosChange(movements[index])
 
     /**
-     * A value class for mouse position changes, packed into a primitive long.
+     * A class for mouse position changes, packed into a primitive long.
      * We utilize bitpacking in order to use primitive long arrays for space
      * constraints.
      * @property packed the bitpacked long value, exposed as servers may wish
@@ -47,8 +46,7 @@ public value class MouseMovements(
      * mouse goes outside the client window, the value will be -1.
      */
     @Suppress("MemberVisibilityCanBePrivate")
-    @JvmInline
-    public value class MousePosChange(
+    public class MousePosChange(
         public val packed: Long,
     ) {
         public constructor(
@@ -56,10 +54,7 @@ public value class MouseMovements(
             xDelta: Int,
             yDelta: Int,
         ) : this(
-            (timeDelta and 0xFFFF)
-                .toLong()
-                .or(xDelta.toLong() and 0xFFFF shl 16)
-                .or(yDelta.toLong() and 0xFFFF shl 32),
+            pack(timeDelta, xDelta, yDelta),
         )
 
         public val timeDelta: Int
@@ -75,5 +70,17 @@ public value class MouseMovements(
                 "xDelta=$xDelta, " +
                 "yDelta=$yDelta" +
                 ")"
+
+        public companion object {
+            public fun pack(
+                timeDelta: Int,
+                xDelta: Int,
+                yDelta: Int,
+            ): Long =
+                (timeDelta and 0xFFFF)
+                    .toLong()
+                    .or(xDelta.toLong() and 0xFFFF shl 16)
+                    .or(yDelta.toLong() and 0xFFFF shl 32)
+        }
     }
 }

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/incoming/messaging/MessagePublic.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/incoming/messaging/MessagePublic.kt
@@ -141,14 +141,13 @@ public class MessagePublic private constructor(
             ")"
 
     /**
-     * A value class for message colour patterns, allowing easy
+     * A class for message colour patterns, allowing easy
      * conversion from the byte array to the respective 24-bit RGB colours.
      * This wrapper class additionally provides a helpful [isValid] function,
      * as it is possible to otherwise send bad data from the client and
      * crash the players in vicinity.
      */
-    @JvmInline
-    public value class MessageColourPattern(
+    public class MessageColourPattern(
         private val bytes: ByteArray,
     ) {
         public val length: Int

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfo.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfo.kt
@@ -89,6 +89,32 @@ public class NpcInfo internal constructor(
     }
 
     /**
+     * Updates the build area of a given world to the specified one.
+     * This will ensure that no NPCs outside of this box will be
+     * added to high resolution view.
+     * @param worldId the id of the world to set the build area of,
+     * with -1 being the root world.
+     * @param zoneX the south-western zone x coordinate of the build area
+     * @param zoneZ the south-western zone z coordinate of the build area
+     * @param widthInZones the build area width in zones (typically 13, meaning 104 tiles)
+     * @param heightInZones the build area height in zones (typically 13, meaning 104 tiles)
+     */
+    @JvmOverloads
+    public fun updateBuildArea(
+        worldId: Int,
+        zoneX: Int,
+        zoneZ: Int,
+        widthInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+        heightInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+    ) {
+        require(worldId == ROOT_WORLD || worldId in 0..<2048) {
+            "World id must be -1 or in range of 0..<2048"
+        }
+        val details = getDetails(worldId)
+        details.buildArea = BuildArea(zoneX, zoneZ, widthInZones, heightInZones)
+    }
+
+    /**
      * Allocates a new NPC info tracking object for the respective [worldId],
      * keeping track of everyone that's within this new world entity.
      * @param worldId the new world entity id

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
@@ -176,6 +176,32 @@ public class PlayerInfo internal constructor(
     }
 
     /**
+     * Updates the build area of a given world to the specified one.
+     * This will ensure that no players outside of this box will be
+     * added to high resolution view.
+     * @param worldId the id of the world to set the build area of,
+     * with -1 being the root world.
+     * @param zoneX the south-western zone x coordinate of the build area
+     * @param zoneZ the south-western zone z coordinate of the build area
+     * @param widthInZones the build area width in zones (typically 13, meaning 104 tiles)
+     * @param heightInZones the build area height in zones (typically 13, meaning 104 tiles)
+     */
+    @JvmOverloads
+    public fun updateBuildArea(
+        worldId: Int,
+        zoneX: Int,
+        zoneZ: Int,
+        widthInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+        heightInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+    ) {
+        require(worldId == ROOT_WORLD || worldId in 0..<2048) {
+            "World id must be -1 or in range of 0..<2048"
+        }
+        val details = getDetails(worldId)
+        details.buildArea = BuildArea(zoneX, zoneZ, widthInZones, heightInZones)
+    }
+
+    /**
      * Allocates a new player info tracking object for the respective [worldId],
      * keeping track of everyone that's within this new world entity.
      * @param worldId the new world entity id

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityInfo.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityInfo.kt
@@ -113,6 +113,24 @@ public class WorldEntityInfo internal constructor(
     }
 
     /**
+     * Updates the build area for this player. This should always perfectly correspond to
+     * the actual build area that is sent via REBUILD_NORMAL or REBUILD_REGION packets.
+     * @property zoneX the south-western zone x coordinate of the build area
+     * @property zoneZ the south-western zone z coordinate of the build area
+     * @property widthInZones the build area width in zones (typically 13, meaning 104 tiles)
+     * @property heightInZones the build area height in zones (typically 13, meaning 104 tiles)
+     */
+    @JvmOverloads
+    public fun updateBuildArea(
+        zoneX: Int,
+        zoneZ: Int,
+        widthInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+        heightInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+    ) {
+        this.buildArea = BuildArea(zoneX, zoneZ, widthInZones, heightInZones)
+    }
+
+    /**
      * Gets a list of all the world entity indices that are currently in high resolution,
      * allowing for correct functionality for player and npc infos, as well as zone updates.
      * @return a list of indices of the world entities currently in high resolution.

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/inv/UpdateInvFull.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/inv/UpdateInvFull.kt
@@ -90,14 +90,14 @@ public class UpdateInvFull private constructor(
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
 
     /**
-     * Gets the obj in the [slot] provided.
+     * Gets the bitpacked obj in the [slot] provided.
      * @param slot the slot in the inventory.
      * @return the inventory object that's in that slot,
      * or [InventoryObject.NULL] if there's no object.
      * @throws IndexOutOfBoundsException if the [slot] is outside
      * the inventory's boundaries.
      */
-    public fun getObject(slot: Int): InventoryObject = inventory[slot]
+    public fun getObject(slot: Int): Long = inventory[slot]
 
     public fun returnInventory() {
         inventory.clear()
@@ -141,11 +141,11 @@ public class UpdateInvFull private constructor(
      */
     public fun interface ObjectProvider {
         /**
-         * Provides an [InventoryObject] instance for a given slot
+         * Provides an [InventoryObject] for a given slot
          * in inventory. If there is no object in that slot,
          * use [InventoryObject.NULL] as an indicator of it.
          */
-        public fun provide(slot: Int): InventoryObject
+        public fun provide(slot: Int): Long
     }
 
     private companion object {
@@ -156,7 +156,7 @@ public class UpdateInvFull private constructor(
          * @param provider the object provider, used to return information
          * about an object in a slot of an inventory.
          * @return an inventory object, which is a compressed representation
-         * of a list of [InventoryObject]s, backed by a long array.
+         * of a list of [InventoryObject]s as longs, backed by a long array.
          */
         private fun buildInventory(
             capacity: Int,
@@ -166,7 +166,7 @@ public class UpdateInvFull private constructor(
             for (i in 0..<capacity) {
                 val obj = provider.provide(i)
                 if (RSProtFlags.inventoryObjCheck) {
-                    check(obj == InventoryObject.NULL || obj.count >= 0) {
+                    check(obj == InventoryObject.NULL || InventoryObject.getCount(obj) >= 0) {
                         "Obj count cannot be below zero: $obj @ $i"
                     }
                 }

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/inv/UpdateInvPartial.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/inv/UpdateInvPartial.kt
@@ -106,14 +106,14 @@ public class UpdateInvPartial private constructor(
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
 
     /**
-     * Gets the obj in the [slot] provided.
+     * Gets the bitpacked obj in the [slot] provided.
      * @param slot the slot in the inventory.
      * @return the inventory object that's in that slot,
      * or [InventoryObject.NULL] if there's no object.
      * @throws IndexOutOfBoundsException if the [slot] is outside
      * the inventory's boundaries.
      */
-    public fun getObject(slot: Int): InventoryObject = inventory[slot]
+    public fun getObject(slot: Int): Long = inventory[slot]
 
     public fun returnInventory() {
         inventory.clear()
@@ -159,11 +159,11 @@ public class UpdateInvPartial private constructor(
         internal val indices: Iterator<Int>,
     ) {
         /**
-         * Provides an [InventoryObject] instance for a given slot
+         * Provides an [InventoryObject] for a given slot
          * in inventory. If there is no object in that slot,
          * use [InventoryObject.NULL] as an indicator of it.
          */
-        public abstract fun provide(slot: Int): InventoryObject
+        public abstract fun provide(slot: Int): Long
     }
 
     private companion object {
@@ -172,7 +172,7 @@ public class UpdateInvPartial private constructor(
          * @param provider the object provider, used to return information
          * about an object in a slot of an inventory.
          * @return an inventory object, which is a compressed representation
-         * of a list of [InventoryObject]s, backed by a long array.
+         * of a list of [InventoryObject]s as longs, backed by a long array.
          */
         private fun buildInventory(provider: IndexedObjectProvider): Inventory {
             val inventory = InventoryPool.pool.borrowObject()
@@ -183,10 +183,10 @@ public class UpdateInvPartial private constructor(
                         "Obj cannot be InventoryObject.NULL for partial updates. Use InventoryObject(slot, -1, -1) " +
                             "instead."
                     }
-                    check(obj.slot >= 0) {
+                    check(InventoryObject.getSlot(obj) >= 0) {
                         "Obj slot cannot be below zero: $obj $ $index"
                     }
-                    check(obj.id == -1 || obj.count >= 0) {
+                    check(InventoryObject.getId(obj) == -1 || InventoryObject.getCount(obj) >= 0) {
                         "Obj count cannot be below zero: $obj @ $index"
                     }
                 }

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/util/RebuildRegionZone.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/util/RebuildRegionZone.kt
@@ -28,6 +28,15 @@ public class RebuildRegionZone private constructor(
         key,
     )
 
+    public val rotation: Int
+        get() = referenceZone.rotation
+    public val zoneX: Int
+        get() = referenceZone.zoneX
+    public val zoneZ: Int
+        get() = referenceZone.zoneZ
+    public val level: Int
+        get() = referenceZone.level
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/util/OpFlags.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/util/OpFlags.kt
@@ -3,70 +3,50 @@ package net.rsprot.protocol.game.outgoing.util
 /**
  * Op flags are used to hide or show certain right-click options on various
  * interactable entities.
- * This is a helper class to create
+ * This is a helper class to create various combinations of this flag.
  */
 @Suppress("MemberVisibilityCanBePrivate")
-@JvmInline
-public value class OpFlags(
-    private val packed: Byte,
-) {
-    public constructor(
+public object OpFlags {
+    /**
+     * A constant flag for 'show all options' on an entity.
+     */
+    public const val ALL_SHOWN: Byte = -1
+
+    /**
+     * A constant flag for 'show no options' on an entity.
+     */
+    public const val NONE_SHOWN: Byte = 0
+
+    @JvmSynthetic
+    public operator fun invoke(
         op1: Boolean,
         op2: Boolean,
         op3: Boolean,
         op4: Boolean,
         op5: Boolean,
-    ) : this(
+    ): Byte = ofOps(op1, op2, op3, op4, op5)
+
+    /**
+     * Returns the bitpacked op flag out of the provided booleans.
+     */
+    @JvmStatic
+    public fun ofOps(
+        op1: Boolean,
+        op2: Boolean,
+        op3: Boolean,
+        op4: Boolean,
+        op5: Boolean,
+    ): Byte =
         toInt(op1)
             .or(toInt(op2) shl 1)
             .or(toInt(op3) shl 2)
             .or(toInt(op4) shl 3)
             .or(toInt(op5) shl 4)
-            .toByte(),
-    )
-
-    public val value: Int
-        get() = packed.toInt()
+            .toByte()
 
     /**
-     * Checks if an option is enabled.
-     * @param op the id of the option, in range of 1 to 5 (inclusive).
-     * @return whether the given option is enabled.
-     * @throws IllegalArgumentException if the option is out of bounds (not in range of 1..5)
+     * Turns the boolean to an integer.
+     * @return 1 if the boolean is enabled, 0 otherwise.
      */
-    public fun isEnabled(op: Int): Boolean {
-        require(op in 1..5) {
-            "Unexpected op value: $op"
-        }
-        val index = op - 1
-        val flag = 1 shl index
-        return packed.toInt() and flag != 0
-    }
-
-    override fun toString(): String =
-        "OpFlags(" +
-            "op1=${isEnabled(1)}, " +
-            "op2=${isEnabled(2)}, " +
-            "op3=${isEnabled(3)}, " +
-            "op4=${isEnabled(4)}, " +
-            "op5=${isEnabled(5)}" +
-            ")"
-
-    public companion object {
-        /**
-         * A constant flag for 'show all options' on an entity.
-         */
-        public val ALL_SHOWN: OpFlags = OpFlags(-1)
-
-        /**
-         * A constant flag for 'show no options' on an entity.
-         */
-        public val NONE_SHOWN: OpFlags = OpFlags(0)
-
-        /**
-         * Turns the boolean to an integer.
-         * @return 1 if the boolean is enabled, 0 otherwise.
-         */
-        private fun toInt(value: Boolean): Int = if (value) 1 else 0
-    }
+    private fun toInt(value: Boolean): Int = if (value) 1 else 0
 }

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/LocAddChange.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/LocAddChange.kt
@@ -3,7 +3,6 @@ package net.rsprot.protocol.game.outgoing.zone.payload
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.common.game.outgoing.codec.zone.payload.OldSchoolZoneProt
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
-import net.rsprot.protocol.game.outgoing.util.OpFlags
 import net.rsprot.protocol.game.outgoing.zone.payload.util.CoordInZone
 import net.rsprot.protocol.game.outgoing.zone.payload.util.LocProperties
 import net.rsprot.protocol.message.ZoneProt
@@ -21,12 +20,14 @@ import net.rsprot.protocol.message.ZoneProt
  * @property shape the shape of the loc, a value of 0 to 22 (inclusive) is expected.
  * @property rotation the rotation of the loc, a value of 0 to 3 (inclusive) is expected.
  * @property opFlags the right-click options enabled on this loc.
+ * Use the [net.rsprot.protocol.game.outgoing.util.OpFlags] helper object to create these
+ * bitpacked values which can be passed into it.
  */
 public class LocAddChange private constructor(
     private val _id: UShort,
     private val coordInZone: CoordInZone,
     private val locProperties: LocProperties,
-    public val opFlags: OpFlags,
+    public val opFlags: Byte,
 ) : ZoneProt {
     public constructor(
         id: Int,
@@ -34,7 +35,7 @@ public class LocAddChange private constructor(
         zInZone: Int,
         shape: Int,
         rotation: Int,
-        opFlags: OpFlags,
+        opFlags: Byte,
     ) : this(
         id.toUShort(),
         CoordInZone(xInZone, zInZone),

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/ObjAdd.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/ObjAdd.kt
@@ -3,7 +3,6 @@ package net.rsprot.protocol.game.outgoing.zone.payload
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.common.game.outgoing.codec.zone.payload.OldSchoolZoneProt
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
-import net.rsprot.protocol.game.outgoing.util.OpFlags
 import net.rsprot.protocol.game.outgoing.zone.payload.util.CoordInZone
 import net.rsprot.protocol.message.ZoneProt
 
@@ -27,6 +26,8 @@ import net.rsprot.protocol.message.ZoneProt
  * @property zInZone the z coordinate of the obj within the zone it is in,
  * a value in range of 0 to 7 (inclusive) is expected. Any bits outside that are ignored.
  * @property opFlags the right-click options enabled on this obj.
+ * Use the [net.rsprot.protocol.game.outgoing.util.OpFlags] helper object to create these
+ * bitpacked values which can be passed into it.
  * @property timeUntilPublic how many game cycles until the obj turns public.
  * This property is only used on the C++-based clients.
  * @property timeUntilDespawn how many game cycles until the obj disappears.
@@ -41,7 +42,7 @@ public class ObjAdd private constructor(
     private val _id: UShort,
     public val quantity: Int,
     private val coordInZone: CoordInZone,
-    public val opFlags: OpFlags,
+    public val opFlags: Byte,
     private val _timeUntilPublic: UShort,
     private val _timeUntilDespawn: UShort,
     private val _ownershipType: UByte,
@@ -52,7 +53,7 @@ public class ObjAdd private constructor(
         quantity: Int,
         xInZone: Int,
         zInZone: Int,
-        opFlags: OpFlags,
+        opFlags: Byte,
         timeUntilPublic: Int,
         timeUntilDespawn: Int,
         ownershipType: Int,
@@ -78,7 +79,7 @@ public class ObjAdd private constructor(
         quantity: Int,
         xInZone: Int,
         zInZone: Int,
-        opFlags: OpFlags,
+        opFlags: Byte,
     ) : this(
         id,
         quantity,

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/ObjEnabledOps.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/ObjEnabledOps.kt
@@ -3,7 +3,6 @@ package net.rsprot.protocol.game.outgoing.zone.payload
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.common.game.outgoing.codec.zone.payload.OldSchoolZoneProt
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
-import net.rsprot.protocol.game.outgoing.util.OpFlags
 import net.rsprot.protocol.game.outgoing.zone.payload.util.CoordInZone
 import net.rsprot.protocol.message.ZoneProt
 
@@ -13,7 +12,9 @@ import net.rsprot.protocol.message.ZoneProt
  * It works by finding the first obj in the stack with the provided [id],
  * and modifying the right-click ops on that. It does not verify quantity.
  * @property id the id of the obj that needs to get its ops changed
- * @property opFlags the right-click options to set enabled on that obj
+ * @property opFlags the right-click options to set enabled on that obj.
+ * Use the [net.rsprot.protocol.game.outgoing.util.OpFlags] helper object to create these
+ * bitpacked values which can be passed into it.
  * @property xInZone the x coordinate of the obj within the zone it is in,
  * a value in range of 0 to 7 (inclusive) is expected. Any bits outside that are ignored.
  * @property zInZone the z coordinate of the obj within the zone it is in,
@@ -21,12 +22,12 @@ import net.rsprot.protocol.message.ZoneProt
  */
 public class ObjEnabledOps private constructor(
     private val _id: UShort,
-    public val opFlags: OpFlags,
+    public val opFlags: Byte,
     private val coordInZone: CoordInZone,
 ) : ZoneProt {
     public constructor(
         id: Int,
-        opFlags: OpFlags,
+        opFlags: Byte,
         xInZone: Int,
         zInZone: Int,
     ) : this(

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/pow/challenges/sha256/DefaultSha256ProofOfWorkProvider.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/pow/challenges/sha256/DefaultSha256ProofOfWorkProvider.kt
@@ -4,12 +4,11 @@ import net.rsprot.protocol.loginprot.incoming.pow.ProofOfWorkProvider
 import net.rsprot.protocol.loginprot.incoming.pow.SingleTypeProofOfWorkProvider
 
 /**
- * A value class to wrap the properties of a SHA-256 into a single instance.
+ * A class to wrap the properties of a SHA-256 into a single instance.
  * @property provider the SHA-256 proof of work provider.
  */
 @Suppress("MemberVisibilityCanBePrivate")
-@JvmInline
-public value class DefaultSha256ProofOfWorkProvider private constructor(
+public class DefaultSha256ProofOfWorkProvider private constructor(
     public val provider: SingleTypeProofOfWorkProvider<Sha256Challenge, Sha256MetaData>,
 ) : ProofOfWorkProvider<Sha256Challenge, Sha256MetaData> by provider {
     public constructor(

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/Password.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/Password.kt
@@ -1,12 +1,11 @@
 package net.rsprot.protocol.loginprot.incoming.util
 
 /**
- * A value class to hold the password.
+ * A class to hold the password.
  * This class offers additional functionality to clear the data from memory,
  * to avoid any potential memory attacks.
  */
-@JvmInline
-public value class Password(
+public class Password(
     public val data: ByteArray,
 ) {
     /**

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/Token.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/Token.kt
@@ -1,12 +1,11 @@
 package net.rsprot.protocol.loginprot.incoming.util
 
 /**
- * A value class to hold the login token.
+ * A class to hold the login token.
  * This class offers additional functionality to clear the data from memory,
  * to avoid any potential memory attacks.
  */
-@JvmInline
-public value class Token(
+public class Token(
     public val data: ByteArray,
 ) {
     /**

--- a/protocol/osrs-225/osrs-225-common/src/main/kotlin/net/rsprot/protocol/common/game/outgoing/inv/InventoryObject.kt
+++ b/protocol/osrs-225/osrs-225-common/src/main/kotlin/net/rsprot/protocol/common/game/outgoing/inv/InventoryObject.kt
@@ -1,63 +1,50 @@
 package net.rsprot.protocol.common.game.outgoing.inv
 
 /**
- * Inventory objects are a value class around the primitive 'long'
- * to efficiently compress an inventory's contents into a long array.
- * This allows us to avoid any garbage creation that would otherwise
- * be created by making lists of objs repeatedly.
+ * Inventory object is a helper object built around the primitive 'long' type.
+ * We utilize longs directly here to reduce the effects of garbage creation
+ * via inventories, as this can otherwise get quite severe with a lot of players.
  */
-@JvmInline
-public value class InventoryObject(
-    public val packed: Long,
-) {
-    public constructor(
+public object InventoryObject {
+    public const val NULL: Long = -1
+
+    @JvmSynthetic
+    public operator fun invoke(
         slot: Int,
         id: Int,
         count: Int,
-    ) : this(
-        (slot.toLong() and 0xFFFF)
-            .or((id.toLong() and 0xFFFF) shl 16)
-            .or((count.toLong() and 0xFFFFFFFF) shl 32),
-    )
+    ): Long = pack(slot, id, count)
 
-    public constructor(
+    @JvmStatic
+    public fun pack(
+        slot: Int,
         id: Int,
         count: Int,
-    ) : this(
-        0,
-        id,
-        count,
-    )
+    ): Long =
+        (slot.toLong() and 0xFFFF)
+            .or((id.toLong() and 0xFFFF) shl 16)
+            .or((count.toLong() and 0xFFFFFFFF) shl 32)
 
-    public val slot: Int
-        get() {
-            val value = (packed and 0xFFFF).toInt()
-            return if (value == 0xFFFF) {
-                -1
-            } else {
-                value
-            }
+    @JvmStatic
+    public fun getSlot(packed: Long): Int {
+        val value = (packed and 0xFFFF).toInt()
+        return if (value == 0xFFFF) {
+            -1
+        } else {
+            value
         }
-    public val id: Int
-        get() {
-            val value = (packed ushr 16 and 0xFFFF).toInt()
-            return if (value == 0xFFFF) {
-                -1
-            } else {
-                value
-            }
-        }
-    public val count: Int
-        get() = (packed ushr 32).toInt()
-
-    override fun toString(): String =
-        "InventoryObject(" +
-            "slot=$slot, " +
-            "id=$id, " +
-            "count=$count" +
-            ")"
-
-    public companion object {
-        public val NULL: InventoryObject = InventoryObject(-1)
     }
+
+    @JvmStatic
+    public fun getId(packed: Long): Int {
+        val value = (packed ushr 16 and 0xFFFF).toInt()
+        return if (value == 0xFFFF) {
+            -1
+        } else {
+            value
+        }
+    }
+
+    @JvmStatic
+    public fun getCount(packed: Long): Int = (packed ushr 32).toInt()
 }

--- a/protocol/osrs-225/osrs-225-desktop/src/main/kotlin/net/rsprot/protocol/game/incoming/codec/events/EventMouseMoveDecoder.kt
+++ b/protocol/osrs-225/osrs-225-desktop/src/main/kotlin/net/rsprot/protocol/game/incoming/codec/events/EventMouseMoveDecoder.kt
@@ -50,12 +50,12 @@ public class EventMouseMoveDecoder : MessageDecoder<EventMouseMove> {
                 deltaY = (packed and 0x3F) - 32
             }
             val change =
-                MouseMovements.MousePosChange(
+                MouseMovements.MousePosChange.pack(
                     timeSinceLastMovement,
                     deltaX,
                     deltaY,
                 )
-            array[count++] = change.packed
+            array[count++] = change
         }
         val slice = array.copyOf(count)
         return EventMouseMove(

--- a/protocol/osrs-225/osrs-225-desktop/src/main/kotlin/net/rsprot/protocol/game/incoming/codec/events/EventNativeMouseMoveDecoder.kt
+++ b/protocol/osrs-225/osrs-225-desktop/src/main/kotlin/net/rsprot/protocol/game/incoming/codec/events/EventNativeMouseMoveDecoder.kt
@@ -51,13 +51,13 @@ public class EventNativeMouseMoveDecoder : MessageDecoder<EventNativeMouseMove> 
             }
             val lastMouseButton = buffer.g1()
             val change =
-                MouseMovements.MousePosChange(
+                MouseMovements.MousePosChange.pack(
                     timeSinceLastMovement,
                     deltaX,
                     deltaY,
                     lastMouseButton,
                 )
-            array[count++] = change.packed
+            array[count++] = change
         }
         val slice = array.copyOf(count)
         return EventNativeMouseMove(

--- a/protocol/osrs-225/osrs-225-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/inv/UpdateInvFullEncoder.kt
+++ b/protocol/osrs-225/osrs-225-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/inv/UpdateInvFullEncoder.kt
@@ -28,12 +28,12 @@ public class UpdateInvFullEncoder : MessageEncoder<UpdateInvFull> {
                 buffer.p2Alt3(0)
                 continue
             }
-            val count = obj.count
+            val count = InventoryObject.getCount(obj)
             buffer.p1Alt2(count.coerceAtMost(0xFF))
             if (count >= 255) {
                 buffer.p4Alt2(count)
             }
-            buffer.p2Alt3(obj.id + 1)
+            buffer.p2Alt3(InventoryObject.getId(obj) + 1)
         }
         message.returnInventory()
     }

--- a/protocol/osrs-225/osrs-225-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/inv/UpdateInvPartialEncoder.kt
+++ b/protocol/osrs-225/osrs-225-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/inv/UpdateInvPartialEncoder.kt
@@ -3,6 +3,7 @@ package net.rsprot.protocol.game.outgoing.codec.inv
 import net.rsprot.buffer.JagByteBuf
 import net.rsprot.crypto.cipher.StreamCipher
 import net.rsprot.protocol.ServerProt
+import net.rsprot.protocol.common.game.outgoing.inv.InventoryObject
 import net.rsprot.protocol.game.outgoing.inv.UpdateInvPartial
 import net.rsprot.protocol.game.outgoing.prot.GameServerProt
 import net.rsprot.protocol.message.codec.MessageEncoder
@@ -22,14 +23,14 @@ public class UpdateInvPartialEncoder : MessageEncoder<UpdateInvPartial> {
         buffer.p2(message.inventoryId)
         for (i in 0..<message.count) {
             val obj = message.getObject(i)
-            buffer.pSmart1or2(obj.slot)
-            val id = obj.id
+            buffer.pSmart1or2(InventoryObject.getSlot(obj))
+            val id = InventoryObject.getId(obj)
             if (id == -1) {
                 buffer.p2(0)
                 continue
             }
             buffer.p2(id + 1)
-            val count = obj.count
+            val count = InventoryObject.getCount(obj)
             buffer.p1(count.coerceAtMost(0xFF))
             if (count >= 0xFF) {
                 buffer.p4(count)

--- a/protocol/osrs-225/osrs-225-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/LocAddChangeEncoder.kt
+++ b/protocol/osrs-225/osrs-225-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/LocAddChangeEncoder.kt
@@ -17,7 +17,7 @@ public class LocAddChangeEncoder : ZoneProtEncoder<LocAddChange> {
         // making it easy to identify all the properties of this packet:
         // loc_add_change_del(world, level, x, z, layer, id, shape, rotation, opFlags, 0, -1)
         buffer.p2Alt2(message.id)
-        buffer.p1Alt2(message.opFlags.value)
+        buffer.p1Alt2(message.opFlags.toInt())
         buffer.p1Alt2(message.locPropertiesPacked)
         buffer.p1Alt2(message.coordInZonePacked)
     }

--- a/protocol/osrs-225/osrs-225-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/ObjAddEncoder.kt
+++ b/protocol/osrs-225/osrs-225-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/ObjAddEncoder.kt
@@ -22,7 +22,7 @@ public class ObjAddEncoder : ZoneProtEncoder<ObjAdd> {
         buffer.p2Alt3(message.id)
         buffer.p2Alt1(message.timeUntilPublic)
         buffer.p1(if (message.neverBecomesPublic) 1 else 0)
-        buffer.p1(message.opFlags.value)
+        buffer.p1(message.opFlags.toInt())
         buffer.p1Alt3(message.ownershipType)
         buffer.p4Alt1(message.quantity)
     }

--- a/protocol/osrs-225/osrs-225-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/ObjEnabledOpsEncoder.kt
+++ b/protocol/osrs-225/osrs-225-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/payload/ObjEnabledOpsEncoder.kt
@@ -18,6 +18,6 @@ public class ObjEnabledOpsEncoder : ZoneProtEncoder<ObjEnabledOps> {
         // obj_opfilter(level, x, z, id, opFlags)
         buffer.p1Alt1(message.coordInZonePacked)
         buffer.p2Alt2(message.id)
-        buffer.p1Alt2(message.opFlags.value)
+        buffer.p1Alt2(message.opFlags.toInt())
     }
 }

--- a/protocol/osrs-225/osrs-225-internal/src/main/kotlin/net/rsprot/protocol/common/game/outgoing/inv/internal/Inventory.kt
+++ b/protocol/osrs-225/osrs-225-internal/src/main/kotlin/net/rsprot/protocol/common/game/outgoing/inv/internal/Inventory.kt
@@ -37,8 +37,8 @@ public class Inventory private constructor(
      * @throws ArrayIndexOutOfBoundsException if the inventory is full
      */
     @Throws(ArrayIndexOutOfBoundsException::class)
-    public fun add(obj: InventoryObject) {
-        contents[count++] = obj.packed
+    public fun add(obj: Long) {
+        contents[count++] = obj
     }
 
     /**
@@ -48,7 +48,7 @@ public class Inventory private constructor(
      * @throws ArrayIndexOutOfBoundsException if the index is out of bounds
      */
     @Throws(ArrayIndexOutOfBoundsException::class)
-    public operator fun get(slot: Int): InventoryObject = InventoryObject(contents[slot])
+    public operator fun get(slot: Int): Long = contents[slot]
 
     /**
      * Clears the inventory by setting the count to zero.

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/incoming/events/EventKeyboard.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/incoming/events/EventKeyboard.kt
@@ -55,8 +55,7 @@ public class EventKeyboard(
      * format back into the normalized [java.awt.event.KeyEvent] format.
      * @property length the length of the key sequence
      */
-    @JvmInline
-    public value class KeySequence(
+    public class KeySequence(
         private val array: ByteArray,
     ) {
         public val length: Int

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/incoming/events/util/MouseMovements.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/incoming/events/util/MouseMovements.kt
@@ -1,13 +1,12 @@
 package net.rsprot.protocol.game.incoming.events.util
 
 /**
- * A value class that wraps around an array of mouse movements,
+ * A class that wraps around an array of mouse movements,
  * with the encoding specified by [MousePosChange].
  * @property length the number of mouse movements in this packet.
  */
 @Suppress("MemberVisibilityCanBePrivate")
-@JvmInline
-public value class MouseMovements(
+public class MouseMovements(
     private val movements: LongArray,
 ) {
     public val length: Int
@@ -34,7 +33,7 @@ public value class MouseMovements(
     public fun getMousePosChange(index: Int): MousePosChange = MousePosChange(movements[index])
 
     /**
-     * A value class for mouse position changes, packed into a primitive long.
+     * A class for mouse position changes, packed into a primitive long.
      * We utilize bitpacking in order to use primitive long arrays for space
      * constraints.
      * @property packed the bitpacked long value, exposed as servers may wish
@@ -53,8 +52,7 @@ public value class MouseMovements(
      * the case for the java variant of this packet.
      */
     @Suppress("MemberVisibilityCanBePrivate")
-    @JvmInline
-    public value class MousePosChange(
+    public class MousePosChange(
         public val packed: Long,
     ) {
         public constructor(
@@ -74,11 +72,7 @@ public value class MouseMovements(
             yDelta: Int,
             lastMouseButton: Int,
         ) : this(
-            (timeDelta and 0xFFFF)
-                .toLong()
-                .or(xDelta.toLong() and 0xFFFF shl 16)
-                .or(yDelta.toLong() and 0xFFFF shl 32)
-                .or(lastMouseButton.toLong() and 0xFFFF shl 48),
+            pack(timeDelta, xDelta, yDelta, lastMouseButton),
         )
 
         public val timeDelta: Int
@@ -97,5 +91,31 @@ public value class MouseMovements(
                 "yDelta=$yDelta" +
                 (if (lastMouseButton != 0xFFFF) "lastMouseButton=$lastMouseButton" else "") +
                 ")"
+
+        public companion object {
+            public fun pack(
+                timeDelta: Int,
+                xDelta: Int,
+                yDelta: Int,
+            ): Long =
+                pack(
+                    timeDelta,
+                    xDelta,
+                    yDelta,
+                    -1,
+                )
+
+            public fun pack(
+                timeDelta: Int,
+                xDelta: Int,
+                yDelta: Int,
+                lastMouseButton: Int,
+            ): Long =
+                (timeDelta and 0xFFFF)
+                    .toLong()
+                    .or(xDelta.toLong() and 0xFFFF shl 16)
+                    .or(yDelta.toLong() and 0xFFFF shl 32)
+                    .or(lastMouseButton.toLong() and 0xFFFF shl 48)
+        }
     }
 }

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/incoming/messaging/MessagePublic.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/incoming/messaging/MessagePublic.kt
@@ -141,14 +141,13 @@ public class MessagePublic private constructor(
             ")"
 
     /**
-     * A value class for message colour patterns, allowing easy
+     * A class for message colour patterns, allowing easy
      * conversion from the byte array to the respective 24-bit RGB colours.
      * This wrapper class additionally provides a helpful [isValid] function,
      * as it is possible to otherwise send bad data from the client and
      * crash the players in vicinity.
      */
-    @JvmInline
-    public value class MessageColourPattern(
+    public class MessageColourPattern(
         private val bytes: ByteArray,
     ) {
         public val length: Int

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfo.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/npcinfo/NpcInfo.kt
@@ -89,6 +89,32 @@ public class NpcInfo internal constructor(
     }
 
     /**
+     * Updates the build area of a given world to the specified one.
+     * This will ensure that no NPCs outside of this box will be
+     * added to high resolution view.
+     * @param worldId the id of the world to set the build area of,
+     * with -1 being the root world.
+     * @param zoneX the south-western zone x coordinate of the build area
+     * @param zoneZ the south-western zone z coordinate of the build area
+     * @param widthInZones the build area width in zones (typically 13, meaning 104 tiles)
+     * @param heightInZones the build area height in zones (typically 13, meaning 104 tiles)
+     */
+    @JvmOverloads
+    public fun updateBuildArea(
+        worldId: Int,
+        zoneX: Int,
+        zoneZ: Int,
+        widthInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+        heightInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+    ) {
+        require(worldId == ROOT_WORLD || worldId in 0..<2048) {
+            "World id must be -1 or in range of 0..<2048"
+        }
+        val details = getDetails(worldId)
+        details.buildArea = BuildArea(zoneX, zoneZ, widthInZones, heightInZones)
+    }
+
+    /**
      * Allocates a new NPC info tracking object for the respective [worldId],
      * keeping track of everyone that's within this new world entity.
      * @param worldId the new world entity id

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/playerinfo/PlayerInfo.kt
@@ -219,6 +219,32 @@ public class PlayerInfo internal constructor(
     }
 
     /**
+     * Updates the build area of a given world to the specified one.
+     * This will ensure that no players outside of this box will be
+     * added to high resolution view.
+     * @param worldId the id of the world to set the build area of,
+     * with -1 being the root world.
+     * @param zoneX the south-western zone x coordinate of the build area
+     * @param zoneZ the south-western zone z coordinate of the build area
+     * @param widthInZones the build area width in zones (typically 13, meaning 104 tiles)
+     * @param heightInZones the build area height in zones (typically 13, meaning 104 tiles)
+     */
+    @JvmOverloads
+    public fun updateBuildArea(
+        worldId: Int,
+        zoneX: Int,
+        zoneZ: Int,
+        widthInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+        heightInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+    ) {
+        require(worldId == ROOT_WORLD || worldId in 0..<2048) {
+            "World id must be -1 or in range of 0..<2048"
+        }
+        val details = getDetails(worldId)
+        details.buildArea = BuildArea(zoneX, zoneZ, widthInZones, heightInZones)
+    }
+
+    /**
      * Allocates a new player info tracking object for the respective [worldId],
      * keeping track of everyone that's within this new world entity.
      * @param worldId the new world entity id

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityInfo.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityInfo.kt
@@ -113,6 +113,24 @@ public class WorldEntityInfo internal constructor(
     }
 
     /**
+     * Updates the build area for this player. This should always perfectly correspond to
+     * the actual build area that is sent via REBUILD_NORMAL or REBUILD_REGION packets.
+     * @property zoneX the south-western zone x coordinate of the build area
+     * @property zoneZ the south-western zone z coordinate of the build area
+     * @property widthInZones the build area width in zones (typically 13, meaning 104 tiles)
+     * @property heightInZones the build area height in zones (typically 13, meaning 104 tiles)
+     */
+    @JvmOverloads
+    public fun updateBuildArea(
+        zoneX: Int,
+        zoneZ: Int,
+        widthInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+        heightInZones: Int = BuildArea.DEFAULT_BUILD_AREA_SIZE,
+    ) {
+        this.buildArea = BuildArea(zoneX, zoneZ, widthInZones, heightInZones)
+    }
+
+    /**
      * Gets a list of all the world entity indices that are currently in high resolution,
      * allowing for correct functionality for player and npc infos, as well as zone updates.
      * @return a list of indices of the world entities currently in high resolution.

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/inv/UpdateInvFull.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/inv/UpdateInvFull.kt
@@ -90,14 +90,14 @@ public class UpdateInvFull private constructor(
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
 
     /**
-     * Gets the obj in the [slot] provided.
+     * Gets the bitpacked obj in the [slot] provided.
      * @param slot the slot in the inventory.
      * @return the inventory object that's in that slot,
      * or [InventoryObject.NULL] if there's no object.
      * @throws IndexOutOfBoundsException if the [slot] is outside
      * the inventory's boundaries.
      */
-    public fun getObject(slot: Int): InventoryObject = inventory[slot]
+    public fun getObject(slot: Int): Long = inventory[slot]
 
     public fun returnInventory() {
         inventory.clear()
@@ -141,11 +141,11 @@ public class UpdateInvFull private constructor(
      */
     public fun interface ObjectProvider {
         /**
-         * Provides an [InventoryObject] instance for a given slot
+         * Provides an [InventoryObject] for a given slot
          * in inventory. If there is no object in that slot,
          * use [InventoryObject.NULL] as an indicator of it.
          */
-        public fun provide(slot: Int): InventoryObject
+        public fun provide(slot: Int): Long
     }
 
     private companion object {
@@ -156,7 +156,7 @@ public class UpdateInvFull private constructor(
          * @param provider the object provider, used to return information
          * about an object in a slot of an inventory.
          * @return an inventory object, which is a compressed representation
-         * of a list of [InventoryObject]s, backed by a long array.
+         * of a list of [InventoryObject]s as longs, backed by a long array.
          */
         private fun buildInventory(
             capacity: Int,
@@ -166,7 +166,7 @@ public class UpdateInvFull private constructor(
             for (i in 0..<capacity) {
                 val obj = provider.provide(i)
                 if (RSProtFlags.inventoryObjCheck) {
-                    check(obj == InventoryObject.NULL || obj.count >= 0) {
+                    check(obj == InventoryObject.NULL || InventoryObject.getCount(obj) >= 0) {
                         "Obj count cannot be below zero: $obj @ $i"
                     }
                 }

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/inv/UpdateInvPartial.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/inv/UpdateInvPartial.kt
@@ -106,14 +106,14 @@ public class UpdateInvPartial private constructor(
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
 
     /**
-     * Gets the obj in the [slot] provided.
+     * Gets the bitpacked obj in the [slot] provided.
      * @param slot the slot in the inventory.
      * @return the inventory object that's in that slot,
      * or [InventoryObject.NULL] if there's no object.
      * @throws IndexOutOfBoundsException if the [slot] is outside
      * the inventory's boundaries.
      */
-    public fun getObject(slot: Int): InventoryObject = inventory[slot]
+    public fun getObject(slot: Int): Long = inventory[slot]
 
     public fun returnInventory() {
         inventory.clear()
@@ -159,11 +159,11 @@ public class UpdateInvPartial private constructor(
         internal val indices: Iterator<Int>,
     ) {
         /**
-         * Provides an [InventoryObject] instance for a given slot
+         * Provides an [InventoryObject] for a given slot
          * in inventory. If there is no object in that slot,
          * use [InventoryObject.NULL] as an indicator of it.
          */
-        public abstract fun provide(slot: Int): InventoryObject
+        public abstract fun provide(slot: Int): Long
     }
 
     private companion object {
@@ -172,7 +172,7 @@ public class UpdateInvPartial private constructor(
          * @param provider the object provider, used to return information
          * about an object in a slot of an inventory.
          * @return an inventory object, which is a compressed representation
-         * of a list of [InventoryObject]s, backed by a long array.
+         * of a list of [InventoryObject]s as longs, backed by a long array.
          */
         private fun buildInventory(provider: IndexedObjectProvider): Inventory {
             val inventory = InventoryPool.pool.borrowObject()
@@ -183,10 +183,10 @@ public class UpdateInvPartial private constructor(
                         "Obj cannot be InventoryObject.NULL for partial updates. Use InventoryObject(slot, -1, -1) " +
                             "instead."
                     }
-                    check(obj.slot >= 0) {
+                    check(InventoryObject.getSlot(obj) >= 0) {
                         "Obj slot cannot be below zero: $obj $ $index"
                     }
-                    check(obj.id == -1 || obj.count >= 0) {
+                    check(InventoryObject.getId(obj) == -1 || InventoryObject.getCount(obj) >= 0) {
                         "Obj count cannot be below zero: $obj @ $index"
                     }
                 }

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/util/RebuildRegionZone.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/util/RebuildRegionZone.kt
@@ -28,6 +28,18 @@ public class RebuildRegionZone private constructor(
         key,
     )
 
+    public val rotation: Int
+        get() = referenceZone.rotation
+    public val zoneX: Int
+        get() = referenceZone.zoneX
+    public val zoneZ: Int
+        get() = referenceZone.zoneZ
+    public val level: Int
+        get() = referenceZone.level
+
+    public val mapsquareId: Int
+        get() = ((zoneX ushr 3) shl 8) or (zoneZ ushr 3)
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/util/OpFlags.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/util/OpFlags.kt
@@ -3,70 +3,50 @@ package net.rsprot.protocol.game.outgoing.util
 /**
  * Op flags are used to hide or show certain right-click options on various
  * interactable entities.
- * This is a helper class to create
+ * This is a helper class to create various combinations of this flag.
  */
 @Suppress("MemberVisibilityCanBePrivate")
-@JvmInline
-public value class OpFlags(
-    private val packed: Byte,
-) {
-    public constructor(
+public object OpFlags {
+    /**
+     * A constant flag for 'show all options' on an entity.
+     */
+    public const val ALL_SHOWN: Byte = -1
+
+    /**
+     * A constant flag for 'show no options' on an entity.
+     */
+    public const val NONE_SHOWN: Byte = 0
+
+    @JvmSynthetic
+    public operator fun invoke(
         op1: Boolean,
         op2: Boolean,
         op3: Boolean,
         op4: Boolean,
         op5: Boolean,
-    ) : this(
+    ): Byte = ofOps(op1, op2, op3, op4, op5)
+
+    /**
+     * Returns the bitpacked op flag out of the provided booleans.
+     */
+    @JvmStatic
+    public fun ofOps(
+        op1: Boolean,
+        op2: Boolean,
+        op3: Boolean,
+        op4: Boolean,
+        op5: Boolean,
+    ): Byte =
         toInt(op1)
             .or(toInt(op2) shl 1)
             .or(toInt(op3) shl 2)
             .or(toInt(op4) shl 3)
             .or(toInt(op5) shl 4)
-            .toByte(),
-    )
-
-    public val value: Int
-        get() = packed.toInt()
+            .toByte()
 
     /**
-     * Checks if an option is enabled.
-     * @param op the id of the option, in range of 1 to 5 (inclusive).
-     * @return whether the given option is enabled.
-     * @throws IllegalArgumentException if the option is out of bounds (not in range of 1..5)
+     * Turns the boolean to an integer.
+     * @return 1 if the boolean is enabled, 0 otherwise.
      */
-    public fun isEnabled(op: Int): Boolean {
-        require(op in 1..5) {
-            "Unexpected op value: $op"
-        }
-        val index = op - 1
-        val flag = 1 shl index
-        return packed.toInt() and flag != 0
-    }
-
-    override fun toString(): String =
-        "OpFlags(" +
-            "op1=${isEnabled(1)}, " +
-            "op2=${isEnabled(2)}, " +
-            "op3=${isEnabled(3)}, " +
-            "op4=${isEnabled(4)}, " +
-            "op5=${isEnabled(5)}" +
-            ")"
-
-    public companion object {
-        /**
-         * A constant flag for 'show all options' on an entity.
-         */
-        public val ALL_SHOWN: OpFlags = OpFlags(-1)
-
-        /**
-         * A constant flag for 'show no options' on an entity.
-         */
-        public val NONE_SHOWN: OpFlags = OpFlags(0)
-
-        /**
-         * Turns the boolean to an integer.
-         * @return 1 if the boolean is enabled, 0 otherwise.
-         */
-        private fun toInt(value: Boolean): Int = if (value) 1 else 0
-    }
+    private fun toInt(value: Boolean): Int = if (value) 1 else 0
 }

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/LocAddChange.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/LocAddChange.kt
@@ -3,7 +3,6 @@ package net.rsprot.protocol.game.outgoing.zone.payload
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.common.game.outgoing.codec.zone.payload.OldSchoolZoneProt
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
-import net.rsprot.protocol.game.outgoing.util.OpFlags
 import net.rsprot.protocol.game.outgoing.zone.payload.util.CoordInZone
 import net.rsprot.protocol.game.outgoing.zone.payload.util.LocProperties
 import net.rsprot.protocol.message.ZoneProt
@@ -21,12 +20,14 @@ import net.rsprot.protocol.message.ZoneProt
  * @property shape the shape of the loc, a value of 0 to 22 (inclusive) is expected.
  * @property rotation the rotation of the loc, a value of 0 to 3 (inclusive) is expected.
  * @property opFlags the right-click options enabled on this loc.
+ * Use the [net.rsprot.protocol.game.outgoing.util.OpFlags] helper object to create these
+ * bitpacked values which can be passed into it.
  */
 public class LocAddChange private constructor(
     private val _id: UShort,
     private val coordInZone: CoordInZone,
     private val locProperties: LocProperties,
-    public val opFlags: OpFlags,
+    public val opFlags: Byte,
 ) : ZoneProt {
     public constructor(
         id: Int,
@@ -34,7 +35,7 @@ public class LocAddChange private constructor(
         zInZone: Int,
         shape: Int,
         rotation: Int,
-        opFlags: OpFlags,
+        opFlags: Byte,
     ) : this(
         id.toUShort(),
         CoordInZone(xInZone, zInZone),

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/ObjAdd.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/ObjAdd.kt
@@ -3,7 +3,6 @@ package net.rsprot.protocol.game.outgoing.zone.payload
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.common.game.outgoing.codec.zone.payload.OldSchoolZoneProt
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
-import net.rsprot.protocol.game.outgoing.util.OpFlags
 import net.rsprot.protocol.game.outgoing.zone.payload.util.CoordInZone
 import net.rsprot.protocol.message.ZoneProt
 
@@ -27,6 +26,8 @@ import net.rsprot.protocol.message.ZoneProt
  * @property zInZone the z coordinate of the obj within the zone it is in,
  * a value in range of 0 to 7 (inclusive) is expected. Any bits outside that are ignored.
  * @property opFlags the right-click options enabled on this obj.
+ * Use the [net.rsprot.protocol.game.outgoing.util.OpFlags] helper object to create these
+ * bitpacked values which can be passed into it.
  * @property timeUntilPublic how many game cycles until the obj turns public.
  * This property is only used on the C++-based clients.
  * @property timeUntilDespawn how many game cycles until the obj disappears.
@@ -41,7 +42,7 @@ public class ObjAdd private constructor(
     private val _id: UShort,
     public val quantity: Int,
     private val coordInZone: CoordInZone,
-    public val opFlags: OpFlags,
+    public val opFlags: Byte,
     private val _timeUntilPublic: UShort,
     private val _timeUntilDespawn: UShort,
     private val _ownershipType: UByte,
@@ -52,7 +53,7 @@ public class ObjAdd private constructor(
         quantity: Int,
         xInZone: Int,
         zInZone: Int,
-        opFlags: OpFlags,
+        opFlags: Byte,
         timeUntilPublic: Int,
         timeUntilDespawn: Int,
         ownershipType: Int,
@@ -78,7 +79,7 @@ public class ObjAdd private constructor(
         quantity: Int,
         xInZone: Int,
         zInZone: Int,
-        opFlags: OpFlags,
+        opFlags: Byte,
     ) : this(
         id,
         quantity,

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/ObjEnabledOps.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/payload/ObjEnabledOps.kt
@@ -3,7 +3,6 @@ package net.rsprot.protocol.game.outgoing.zone.payload
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.common.game.outgoing.codec.zone.payload.OldSchoolZoneProt
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
-import net.rsprot.protocol.game.outgoing.util.OpFlags
 import net.rsprot.protocol.game.outgoing.zone.payload.util.CoordInZone
 import net.rsprot.protocol.message.ZoneProt
 
@@ -13,7 +12,9 @@ import net.rsprot.protocol.message.ZoneProt
  * It works by finding the first obj in the stack with the provided [id],
  * and modifying the right-click ops on that. It does not verify quantity.
  * @property id the id of the obj that needs to get its ops changed
- * @property opFlags the right-click options to set enabled on that obj
+ * @property opFlags the right-click options to set enabled on that obj.
+ * Use the [net.rsprot.protocol.game.outgoing.util.OpFlags] helper object to create these
+ * bitpacked values which can be passed into it.
  * @property xInZone the x coordinate of the obj within the zone it is in,
  * a value in range of 0 to 7 (inclusive) is expected. Any bits outside that are ignored.
  * @property zInZone the z coordinate of the obj within the zone it is in,
@@ -21,12 +22,12 @@ import net.rsprot.protocol.message.ZoneProt
  */
 public class ObjEnabledOps private constructor(
     private val _id: UShort,
-    public val opFlags: OpFlags,
+    public val opFlags: Byte,
     private val coordInZone: CoordInZone,
 ) : ZoneProt {
     public constructor(
         id: Int,
-        opFlags: OpFlags,
+        opFlags: Byte,
         xInZone: Int,
         zInZone: Int,
     ) : this(

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/pow/challenges/sha256/DefaultSha256ProofOfWorkProvider.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/pow/challenges/sha256/DefaultSha256ProofOfWorkProvider.kt
@@ -4,12 +4,11 @@ import net.rsprot.protocol.loginprot.incoming.pow.ProofOfWorkProvider
 import net.rsprot.protocol.loginprot.incoming.pow.SingleTypeProofOfWorkProvider
 
 /**
- * A value class to wrap the properties of a SHA-256 into a single instance.
+ * A class to wrap the properties of a SHA-256 into a single instance.
  * @property provider the SHA-256 proof of work provider.
  */
 @Suppress("MemberVisibilityCanBePrivate")
-@JvmInline
-public value class DefaultSha256ProofOfWorkProvider private constructor(
+public class DefaultSha256ProofOfWorkProvider private constructor(
     public val provider: SingleTypeProofOfWorkProvider<Sha256Challenge, Sha256MetaData>,
 ) : ProofOfWorkProvider<Sha256Challenge, Sha256MetaData> by provider {
     public constructor(

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/Password.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/Password.kt
@@ -1,12 +1,11 @@
 package net.rsprot.protocol.loginprot.incoming.util
 
 /**
- * A value class to hold the password.
+ * A class to hold the password.
  * This class offers additional functionality to clear the data from memory,
  * to avoid any potential memory attacks.
  */
-@JvmInline
-public value class Password(
+public class Password(
     public val data: ByteArray,
 ) {
     /**

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/Token.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/Token.kt
@@ -1,12 +1,11 @@
 package net.rsprot.protocol.loginprot.incoming.util
 
 /**
- * A value class to hold the login token.
+ * A class to hold the login token.
  * This class offers additional functionality to clear the data from memory,
  * to avoid any potential memory attacks.
  */
-@JvmInline
-public value class Token(
+public class Token(
     public val data: ByteArray,
 ) {
     /**


### PR DESCRIPTION
This PR refactors a sizable chunk of the codebase where value classes were previously used, namely the areas which had public-facing value classes. We had to eliminate this because any function or constructor that uses a value class object is completely invisible to anyone trying to implement RSProt from a purely java server. The only way to get around this before was to make a few helper classes in Kotlin to bridge the gap.

In most cases, these public-facing value classes provided no measurable benefits anyhow and were just converted to a traditional class. In cases where it does matter, such as inventory updates, going from a primitive long to a boxed Long means increasing the memory consumption by 3x (8 bytes for long, 12 bytes for object header, 4 bytes for 8-byte padding). In cases like that, we had to switch over to using the primitive long in the public facing code, instead of the value class. For existing servers, however, there is no expected change necessary (other than maybe changing the return type from InventoryObject to long), as we created a fake constructor via operator fun invoke on the companion that mimics the old usage.