### PR TITLE
feat: add opt-in global packet listener

### DIFF
--- a/protocol/osrs-221/osrs-221-api/src/main/kotlin/net/rsprot/protocol/api/Session.kt
+++ b/protocol/osrs-221/osrs-221-api/src/main/kotlin/net/rsprot/protocol/api/Session.kt
@@ -108,9 +108,17 @@ public class Session<R>(
             }
             try {
                 consumer.consume(receiver, packet)
-                globalConsumers.forEach { it.consume(receiver, packet)  }
             } catch (cause: Throwable) {
                 incomingGameMessageConsumerExceptionHandler.exceptionCaught(this, packet, cause)
+            }
+            if (globalConsumers.isNotEmpty()) {
+                for (globalConsumer in globalConsumers) {
+                    try {
+                        globalConsumer.consume(receiver, packet)
+                    } catch (cause: Throwable) {
+                        incomingGameMessageConsumerExceptionHandler.exceptionCaught(this, packet, cause)
+                    }
+                }
             }
             count++
         }

--- a/protocol/osrs-221/osrs-221-api/src/main/kotlin/net/rsprot/protocol/api/Session.kt
+++ b/protocol/osrs-221/osrs-221-api/src/main/kotlin/net/rsprot/protocol/api/Session.kt
@@ -46,6 +46,7 @@ public class Session<R>(
     outgoingMessageQueueProvider: MessageQueueProvider<OutgoingGameMessage>,
     private val counter: GameMessageCounter,
     private val consumers: Map<Class<out IncomingGameMessage>, MessageConsumer<R, IncomingGameMessage>>,
+    private val globalConsumers: List<MessageConsumer<R, IncomingGameMessage>>,
     public val loginBlock: LoginBlock<*>,
     private val incomingGameMessageConsumerExceptionHandler: IncomingGameMessageConsumerExceptionHandler<R>,
 ) {
@@ -107,6 +108,7 @@ public class Session<R>(
             }
             try {
                 consumer.consume(receiver, packet)
+                globalConsumers.forEach { it.consume(receiver, packet)  }
             } catch (cause: Throwable) {
                 incomingGameMessageConsumerExceptionHandler.exceptionCaught(this, packet, cause)
             }

--- a/protocol/osrs-221/osrs-221-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-221/osrs-221-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -162,6 +162,9 @@ public class GameLoginResponseHandler<R>(
         oldSchoolClientType: OldSchoolClientType,
         encodingCipher: StreamCipher,
     ): Session<R> {
+        val gameMessageConsumerRepository = networkService
+            .gameMessageConsumerRepositoryProvider
+            .provide()
         val session =
             Session(
                 ctx,
@@ -176,10 +179,10 @@ public class GameLoginResponseHandler<R>(
                     .gameMessageHandlers
                     .gameMessageCounterProvider
                     .provide(),
-                networkService
-                    .gameMessageConsumerRepositoryProvider
-                    .provide()
+                gameMessageConsumerRepository
                     .consumers,
+                gameMessageConsumerRepository
+                    .globalConsumers,
                 loginBlock,
                 networkService
                     .exceptionHandlers

--- a/protocol/osrs-222/osrs-222-api/src/main/kotlin/net/rsprot/protocol/api/Session.kt
+++ b/protocol/osrs-222/osrs-222-api/src/main/kotlin/net/rsprot/protocol/api/Session.kt
@@ -108,9 +108,17 @@ public class Session<R>(
             }
             try {
                 consumer.consume(receiver, packet)
-                globalConsumers.forEach { it.consume(receiver, packet)  }
             } catch (cause: Throwable) {
                 incomingGameMessageConsumerExceptionHandler.exceptionCaught(this, packet, cause)
+            }
+            if (globalConsumers.isNotEmpty()) {
+                for (globalConsumer in globalConsumers) {
+                    try {
+                        globalConsumer.consume(receiver, packet)
+                    } catch (cause: Throwable) {
+                        incomingGameMessageConsumerExceptionHandler.exceptionCaught(this, packet, cause)
+                    }
+                }
             }
             count++
         }

--- a/protocol/osrs-222/osrs-222-api/src/main/kotlin/net/rsprot/protocol/api/Session.kt
+++ b/protocol/osrs-222/osrs-222-api/src/main/kotlin/net/rsprot/protocol/api/Session.kt
@@ -46,6 +46,7 @@ public class Session<R>(
     outgoingMessageQueueProvider: MessageQueueProvider<OutgoingGameMessage>,
     private val counter: GameMessageCounter,
     private val consumers: Map<Class<out IncomingGameMessage>, MessageConsumer<R, IncomingGameMessage>>,
+    private val globalConsumers: List<MessageConsumer<R, IncomingGameMessage>>,
     public val loginBlock: LoginBlock<*>,
     private val incomingGameMessageConsumerExceptionHandler: IncomingGameMessageConsumerExceptionHandler<R>,
 ) {
@@ -107,6 +108,7 @@ public class Session<R>(
             }
             try {
                 consumer.consume(receiver, packet)
+                globalConsumers.forEach { it.consume(receiver, packet)  }
             } catch (cause: Throwable) {
                 incomingGameMessageConsumerExceptionHandler.exceptionCaught(this, packet, cause)
             }

--- a/protocol/osrs-222/osrs-222-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-222/osrs-222-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -162,6 +162,9 @@ public class GameLoginResponseHandler<R>(
         oldSchoolClientType: OldSchoolClientType,
         encodingCipher: StreamCipher,
     ): Session<R> {
+        val gameMessageConsumerRepository = networkService
+            .gameMessageConsumerRepositoryProvider
+            .provide()
         val session =
             Session(
                 ctx,
@@ -176,10 +179,10 @@ public class GameLoginResponseHandler<R>(
                     .gameMessageHandlers
                     .gameMessageCounterProvider
                     .provide(),
-                networkService
-                    .gameMessageConsumerRepositoryProvider
-                    .provide()
+                gameMessageConsumerRepository
                     .consumers,
+                gameMessageConsumerRepository
+                    .globalConsumers,
                 loginBlock,
                 networkService
                     .exceptionHandlers

--- a/protocol/osrs-223/osrs-223-api/src/main/kotlin/net/rsprot/protocol/api/Session.kt
+++ b/protocol/osrs-223/osrs-223-api/src/main/kotlin/net/rsprot/protocol/api/Session.kt
@@ -108,9 +108,17 @@ public class Session<R>(
             }
             try {
                 consumer.consume(receiver, packet)
-                globalConsumers.forEach { it.consume(receiver, packet)  }
             } catch (cause: Throwable) {
                 incomingGameMessageConsumerExceptionHandler.exceptionCaught(this, packet, cause)
+            }
+            if (globalConsumers.isNotEmpty()) {
+                for (globalConsumer in globalConsumers) {
+                    try {
+                        globalConsumer.consume(receiver, packet)
+                    } catch (cause: Throwable) {
+                        incomingGameMessageConsumerExceptionHandler.exceptionCaught(this, packet, cause)
+                    }
+                }
             }
             count++
         }

--- a/protocol/osrs-223/osrs-223-api/src/main/kotlin/net/rsprot/protocol/api/Session.kt
+++ b/protocol/osrs-223/osrs-223-api/src/main/kotlin/net/rsprot/protocol/api/Session.kt
@@ -46,6 +46,7 @@ public class Session<R>(
     outgoingMessageQueueProvider: MessageQueueProvider<OutgoingGameMessage>,
     private val counter: GameMessageCounter,
     private val consumers: Map<Class<out IncomingGameMessage>, MessageConsumer<R, IncomingGameMessage>>,
+    private val globalConsumers: List<MessageConsumer<R, IncomingGameMessage>>,
     public val loginBlock: LoginBlock<*>,
     private val incomingGameMessageConsumerExceptionHandler: IncomingGameMessageConsumerExceptionHandler<R>,
 ) {
@@ -107,6 +108,7 @@ public class Session<R>(
             }
             try {
                 consumer.consume(receiver, packet)
+                globalConsumers.forEach { it.consume(receiver, packet)  }
             } catch (cause: Throwable) {
                 incomingGameMessageConsumerExceptionHandler.exceptionCaught(this, packet, cause)
             }

--- a/protocol/osrs-223/osrs-223-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-223/osrs-223-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -162,6 +162,9 @@ public class GameLoginResponseHandler<R>(
         oldSchoolClientType: OldSchoolClientType,
         encodingCipher: StreamCipher,
     ): Session<R> {
+        val gameMessageConsumerRepository = networkService
+            .gameMessageConsumerRepositoryProvider
+            .provide()
         val session =
             Session(
                 ctx,
@@ -176,10 +179,10 @@ public class GameLoginResponseHandler<R>(
                     .gameMessageHandlers
                     .gameMessageCounterProvider
                     .provide(),
-                networkService
-                    .gameMessageConsumerRepositoryProvider
-                    .provide()
+                gameMessageConsumerRepository
                     .consumers,
+                gameMessageConsumerRepository
+                    .globalConsumers,
                 loginBlock,
                 networkService
                     .exceptionHandlers

--- a/protocol/osrs-224/osrs-224-api/src/main/kotlin/net/rsprot/protocol/api/Session.kt
+++ b/protocol/osrs-224/osrs-224-api/src/main/kotlin/net/rsprot/protocol/api/Session.kt
@@ -108,9 +108,17 @@ public class Session<R>(
             }
             try {
                 consumer.consume(receiver, packet)
-                globalConsumers.forEach { it.consume(receiver, packet)  }
             } catch (cause: Throwable) {
                 incomingGameMessageConsumerExceptionHandler.exceptionCaught(this, packet, cause)
+            }
+            if (globalConsumers.isNotEmpty()) {
+                for (globalConsumer in globalConsumers) {
+                    try {
+                        globalConsumer.consume(receiver, packet)
+                    } catch (cause: Throwable) {
+                        incomingGameMessageConsumerExceptionHandler.exceptionCaught(this, packet, cause)
+                    }
+                }
             }
             count++
         }

--- a/protocol/osrs-224/osrs-224-api/src/main/kotlin/net/rsprot/protocol/api/Session.kt
+++ b/protocol/osrs-224/osrs-224-api/src/main/kotlin/net/rsprot/protocol/api/Session.kt
@@ -46,6 +46,7 @@ public class Session<R>(
     outgoingMessageQueueProvider: MessageQueueProvider<OutgoingGameMessage>,
     private val counter: GameMessageCounter,
     private val consumers: Map<Class<out IncomingGameMessage>, MessageConsumer<R, IncomingGameMessage>>,
+    private val globalConsumers: List<MessageConsumer<R, IncomingGameMessage>>,
     public val loginBlock: LoginBlock<*>,
     private val incomingGameMessageConsumerExceptionHandler: IncomingGameMessageConsumerExceptionHandler<R>,
 ) {
@@ -107,6 +108,7 @@ public class Session<R>(
             }
             try {
                 consumer.consume(receiver, packet)
+                globalConsumers.forEach { it.consume(receiver, packet)  }
             } catch (cause: Throwable) {
                 incomingGameMessageConsumerExceptionHandler.exceptionCaught(this, packet, cause)
             }

--- a/protocol/osrs-224/osrs-224-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-224/osrs-224-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -162,6 +162,9 @@ public class GameLoginResponseHandler<R>(
         oldSchoolClientType: OldSchoolClientType,
         encodingCipher: StreamCipher,
     ): Session<R> {
+        val gameMessageConsumerRepository = networkService
+            .gameMessageConsumerRepositoryProvider
+            .provide()
         val session =
             Session(
                 ctx,
@@ -176,10 +179,10 @@ public class GameLoginResponseHandler<R>(
                     .gameMessageHandlers
                     .gameMessageCounterProvider
                     .provide(),
-                networkService
-                    .gameMessageConsumerRepositoryProvider
-                    .provide()
+                gameMessageConsumerRepository
                     .consumers,
+                gameMessageConsumerRepository
+                    .globalConsumers,
                 loginBlock,
                 networkService
                     .exceptionHandlers

--- a/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/Session.kt
+++ b/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/Session.kt
@@ -108,9 +108,17 @@ public class Session<R>(
             }
             try {
                 consumer.consume(receiver, packet)
-                globalConsumers.forEach { it.consume(receiver, packet)  }
             } catch (cause: Throwable) {
                 incomingGameMessageConsumerExceptionHandler.exceptionCaught(this, packet, cause)
+            }
+            if (globalConsumers.isNotEmpty()) {
+                for (globalConsumer in globalConsumers) {
+                    try {
+                        globalConsumer.consume(receiver, packet)
+                    } catch (cause: Throwable) {
+                        incomingGameMessageConsumerExceptionHandler.exceptionCaught(this, packet, cause)
+                    }
+                }
             }
             count++
         }

--- a/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/Session.kt
+++ b/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/Session.kt
@@ -46,6 +46,7 @@ public class Session<R>(
     outgoingMessageQueueProvider: MessageQueueProvider<OutgoingGameMessage>,
     private val counter: GameMessageCounter,
     private val consumers: Map<Class<out IncomingGameMessage>, MessageConsumer<R, IncomingGameMessage>>,
+    private val globalConsumers: List<MessageConsumer<R, IncomingGameMessage>>,
     public val loginBlock: LoginBlock<*>,
     private val incomingGameMessageConsumerExceptionHandler: IncomingGameMessageConsumerExceptionHandler<R>,
 ) {
@@ -107,6 +108,7 @@ public class Session<R>(
             }
             try {
                 consumer.consume(receiver, packet)
+                globalConsumers.forEach { it.consume(receiver, packet)  }
             } catch (cause: Throwable) {
                 incomingGameMessageConsumerExceptionHandler.exceptionCaught(this, packet, cause)
             }

--- a/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -162,6 +162,9 @@ public class GameLoginResponseHandler<R>(
         oldSchoolClientType: OldSchoolClientType,
         encodingCipher: StreamCipher,
     ): Session<R> {
+        val gameMessageConsumerRepository = networkService
+            .gameMessageConsumerRepositoryProvider
+            .provide()
         val session =
             Session(
                 ctx,
@@ -176,10 +179,10 @@ public class GameLoginResponseHandler<R>(
                     .gameMessageHandlers
                     .gameMessageCounterProvider
                     .provide(),
-                networkService
-                    .gameMessageConsumerRepositoryProvider
-                    .provide()
+                gameMessageConsumerRepository
                     .consumers,
+                gameMessageConsumerRepository
+                    .globalConsumers,
                 loginBlock,
                 networkService
                     .exceptionHandlers

--- a/protocol/src/main/kotlin/net/rsprot/protocol/message/codec/incoming/GameMessageConsumerRepository.kt
+++ b/protocol/src/main/kotlin/net/rsprot/protocol/message/codec/incoming/GameMessageConsumerRepository.kt
@@ -22,5 +22,6 @@ public class GameMessageConsumerRepository<R>(
         return result
     }
 
-    override fun toString(): String = "GameMessageConsumerRepository(consumers=$consumers, globalConsumers=$globalConsumers)"
+    override fun toString(): String =
+        "GameMessageConsumerRepository(consumers=$consumers, globalConsumers=$globalConsumers)"
 }

--- a/protocol/src/main/kotlin/net/rsprot/protocol/message/codec/incoming/GameMessageConsumerRepository.kt
+++ b/protocol/src/main/kotlin/net/rsprot/protocol/message/codec/incoming/GameMessageConsumerRepository.kt
@@ -4,17 +4,23 @@ import net.rsprot.protocol.message.IncomingGameMessage
 
 public class GameMessageConsumerRepository<R>(
     public val consumers: Map<Class<out IncomingGameMessage>, MessageConsumer<R, IncomingGameMessage>>,
+    public val globalConsumers: List<MessageConsumer<R, IncomingGameMessage>>,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is GameMessageConsumerRepository<*>) return false
 
         if (consumers != other.consumers) return false
+        if (globalConsumers != other.globalConsumers) return false
 
         return true
     }
 
-    override fun hashCode(): Int = consumers.hashCode()
+    override fun hashCode(): Int {
+        var result = consumers.hashCode()
+        result = 31 * result + globalConsumers.hashCode()
+        return result
+    }
 
-    override fun toString(): String = "GameMessageConsumerRepository(consumers=$consumers)"
+    override fun toString(): String = "GameMessageConsumerRepository(consumers=$consumers, globalConsumers=$globalConsumers)"
 }

--- a/protocol/src/main/kotlin/net/rsprot/protocol/message/codec/incoming/GameMessageConsumerRepositoryBuilder.kt
+++ b/protocol/src/main/kotlin/net/rsprot/protocol/message/codec/incoming/GameMessageConsumerRepositoryBuilder.kt
@@ -47,16 +47,6 @@ public class GameMessageConsumerRepositoryBuilder<R> {
     }
 
     /**
-     * Removes a global listener for [IncomingGameMessage]s.
-     */
-    public fun removeGlobalListener(
-        consumer: MessageConsumer<R, IncomingGameMessage>,
-    ): GameMessageConsumerRepositoryBuilder<R> {
-        globalConsumers.remove(consumer)
-        return this
-    }
-
-    /**
      * Adds a listener for the provided [T]; this function is an overload of the [addListener],
      * intended to make registering listeners from Kotlin easier
      * @param listener the listener of the message.

--- a/protocol/src/main/kotlin/net/rsprot/protocol/message/codec/incoming/GameMessageConsumerRepositoryBuilder.kt
+++ b/protocol/src/main/kotlin/net/rsprot/protocol/message/codec/incoming/GameMessageConsumerRepositoryBuilder.kt
@@ -12,6 +12,7 @@ import net.rsprot.protocol.message.IncomingGameMessage
 public class GameMessageConsumerRepositoryBuilder<R> {
     private val consumers: MutableMap<Class<out IncomingGameMessage>, MessageConsumer<R, IncomingGameMessage>> =
         HashMap()
+    private val globalConsumers: MutableList<MessageConsumer<R, IncomingGameMessage>> = ArrayList()
 
     /**
      * Adds a listener for the provided [clazz].
@@ -35,6 +36,27 @@ public class GameMessageConsumerRepositoryBuilder<R> {
     }
 
     /**
+     * Adds a listener for any type of [IncomingGameMessage].
+     * These listeners are always invoked _after_ listeners registered for specific message types with [addListener].
+     */
+    public fun addGlobalListener(
+        consumer: MessageConsumer<R, IncomingGameMessage>,
+    ): GameMessageConsumerRepositoryBuilder<R> {
+        globalConsumers.add(consumer)
+        return this
+    }
+
+    /**
+     * Removes a global listener for [IncomingGameMessage]s.
+     */
+    public fun removeGlobalListener(
+        consumer: MessageConsumer<R, IncomingGameMessage>,
+    ): GameMessageConsumerRepositoryBuilder<R> {
+        globalConsumers.remove(consumer)
+        return this
+    }
+
+    /**
      * Adds a listener for the provided [T]; this function is an overload of the [addListener],
      * intended to make registering listeners from Kotlin easier
      * @param listener the listener of the message.
@@ -44,5 +66,8 @@ public class GameMessageConsumerRepositoryBuilder<R> {
         crossinline listener: R.(message: T) -> Unit,
     ): GameMessageConsumerRepositoryBuilder<R> = addListener(T::class.java) { r, t -> listener(r, t) }
 
-    public fun build(): GameMessageConsumerRepository<R> = GameMessageConsumerRepository(consumers.toMap(HashMap()))
+    public fun build(): GameMessageConsumerRepository<R> = GameMessageConsumerRepository(
+        consumers.toMap(HashMap()),
+        globalConsumers.toList(),
+    )
 }


### PR DESCRIPTION
Adds 'global consumers' which are invoked for every single packet coming from the client to the server, after type-specific listeners are invoked.

Potential use cases which prompted this:
- Passing through packets, or some derivative of, to some sort of bot detection system.
- Having a way to mark a player as 'active' when any packet, or any packet from a set of packets, are received.

The latter situation is used in August to clear a 'self disconnection' timer on a player that is added when the server receives a valid login request while the player is already logged in.
- Player is logged in
- Player's client DC's, but server keeps their player in the game
- Player's client sends another login request with correct password
- `Player` in-game marked with self-DC timer for 10 seconds that'll try boot them in most situations
- After 10 seconds if no packets are received for that player (which is the case when the client DC's), the player is booted