### PR TITLE
Message Size Estimator

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,6 +19,8 @@ ktlint_custom-rule-set = enabled
 # as disabling at call sites doesn't seem to get recognized properly
 # noinspection EditorConfigKeyCorrectness
 ktlint_standard_backing-property-naming = disabled
+# noinspection EditorConfigKeyCorrectness
+ktlint_standard_function-expression-body = disabled
 
 [*.md]
 max_line_length = 80

--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/js5/outgoing/Js5GroupResponse.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/js5/outgoing/Js5GroupResponse.kt
@@ -8,12 +8,12 @@ import net.rsprot.protocol.message.OutgoingJs5Message
  * Js5 group responses are used to feed the cache to the client through the server.
  * @param buffer the byte buffer that is used for the response
  * @property offset the starting index from which the response is written
- * @property limit the ending index until which the response is written
+ * @property length the length of the message to be written
  */
 public class Js5GroupResponse(
     buffer: ByteBuf,
     public val offset: Int,
-    public val limit: Int,
+    public val length: Int,
     public val key: Int,
 ) : DefaultByteBufHolder(buffer),
     OutgoingJs5Message {
@@ -25,7 +25,7 @@ public class Js5GroupResponse(
         other as Js5GroupResponse
 
         if (offset != other.offset) return false
-        if (limit != other.limit) return false
+        if (length != other.length) return false
 
         return true
     }
@@ -33,13 +33,13 @@ public class Js5GroupResponse(
     override fun hashCode(): Int {
         var result = super.hashCode()
         result = 31 * result + offset
-        result = 31 * result + limit
+        result = 31 * result + length
         return result
     }
 
     override fun toString(): String =
         "Js5GroupResponse(" +
             "offset=$offset, " +
-            "limit=$limit" +
+            "length=$length" +
             ")"
 }

--- a/protocol/osrs-221/osrs-221-shared/src/main/kotlin/net/rsprot/protocol/common/js5/outgoing/codec/Js5GroupResponseEncoder.kt
+++ b/protocol/osrs-221/osrs-221-shared/src/main/kotlin/net/rsprot/protocol/common/js5/outgoing/codec/Js5GroupResponseEncoder.kt
@@ -17,7 +17,7 @@ public class Js5GroupResponseEncoder : MessageEncoder<Js5GroupResponse> {
         message: Js5GroupResponse,
     ) {
         val offset = message.offset
-        val limit = message.limit
+        val length = message.length
         val messageBuf = message.content()
         // Perform a quick one-time validation to ensure the server is yielding the same
         // type bytebuffers that the Netty pipeline is expecting, to avoid very expensive
@@ -39,14 +39,14 @@ public class Js5GroupResponseEncoder : MessageEncoder<Js5GroupResponse> {
         }
         if (message.key != 0) {
             val out = buffer.buffer
-            for (i in offset..<limit) {
-                out.writeByte(messageBuf.getByte(i).toInt() xor message.key)
+            for (i in 0..<length) {
+                out.writeByte(messageBuf.getByte(offset + i).toInt() xor message.key)
             }
         } else {
             buffer.buffer.writeBytes(
                 messageBuf,
                 offset,
-                limit,
+                length,
             )
         }
     }

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/js5/outgoing/Js5GroupResponse.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/js5/outgoing/Js5GroupResponse.kt
@@ -8,12 +8,12 @@ import net.rsprot.protocol.message.OutgoingJs5Message
  * Js5 group responses are used to feed the cache to the client through the server.
  * @param buffer the byte buffer that is used for the response
  * @property offset the starting index from which the response is written
- * @property limit the ending index until which the response is written
+ * @property length the length of the message to be written
  */
 public class Js5GroupResponse(
     buffer: ByteBuf,
     public val offset: Int,
-    public val limit: Int,
+    public val length: Int,
     public val key: Int,
 ) : DefaultByteBufHolder(buffer),
     OutgoingJs5Message {
@@ -25,7 +25,7 @@ public class Js5GroupResponse(
         other as Js5GroupResponse
 
         if (offset != other.offset) return false
-        if (limit != other.limit) return false
+        if (length != other.length) return false
 
         return true
     }
@@ -33,13 +33,13 @@ public class Js5GroupResponse(
     override fun hashCode(): Int {
         var result = super.hashCode()
         result = 31 * result + offset
-        result = 31 * result + limit
+        result = 31 * result + length
         return result
     }
 
     override fun toString(): String =
         "Js5GroupResponse(" +
             "offset=$offset, " +
-            "limit=$limit" +
+            "length=$length" +
             ")"
 }

--- a/protocol/osrs-222/osrs-222-shared/src/main/kotlin/net/rsprot/protocol/common/js5/outgoing/codec/Js5GroupResponseEncoder.kt
+++ b/protocol/osrs-222/osrs-222-shared/src/main/kotlin/net/rsprot/protocol/common/js5/outgoing/codec/Js5GroupResponseEncoder.kt
@@ -17,7 +17,7 @@ public class Js5GroupResponseEncoder : MessageEncoder<Js5GroupResponse> {
         message: Js5GroupResponse,
     ) {
         val offset = message.offset
-        val limit = message.limit
+        val length = message.length
         val messageBuf = message.content()
         // Perform a quick one-time validation to ensure the server is yielding the same
         // type bytebuffers that the Netty pipeline is expecting, to avoid very expensive
@@ -39,14 +39,14 @@ public class Js5GroupResponseEncoder : MessageEncoder<Js5GroupResponse> {
         }
         if (message.key != 0) {
             val out = buffer.buffer
-            for (i in offset..<limit) {
-                out.writeByte(messageBuf.getByte(i).toInt() xor message.key)
+            for (i in 0..<length) {
+                out.writeByte(messageBuf.getByte(offset + i).toInt() xor message.key)
             }
         } else {
             buffer.buffer.writeBytes(
                 messageBuf,
                 offset,
-                limit,
+                length,
             )
         }
     }

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/js5/outgoing/Js5GroupResponse.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/js5/outgoing/Js5GroupResponse.kt
@@ -8,12 +8,12 @@ import net.rsprot.protocol.message.OutgoingJs5Message
  * Js5 group responses are used to feed the cache to the client through the server.
  * @param buffer the byte buffer that is used for the response
  * @property offset the starting index from which the response is written
- * @property limit the ending index until which the response is written
+ * @property length the length of the message to be written
  */
 public class Js5GroupResponse(
     buffer: ByteBuf,
     public val offset: Int,
-    public val limit: Int,
+    public val length: Int,
     public val key: Int,
 ) : DefaultByteBufHolder(buffer),
     OutgoingJs5Message {
@@ -25,7 +25,7 @@ public class Js5GroupResponse(
         other as Js5GroupResponse
 
         if (offset != other.offset) return false
-        if (limit != other.limit) return false
+        if (length != other.length) return false
 
         return true
     }
@@ -33,13 +33,13 @@ public class Js5GroupResponse(
     override fun hashCode(): Int {
         var result = super.hashCode()
         result = 31 * result + offset
-        result = 31 * result + limit
+        result = 31 * result + length
         return result
     }
 
     override fun toString(): String =
         "Js5GroupResponse(" +
             "offset=$offset, " +
-            "limit=$limit" +
+            "length=$length" +
             ")"
 }

--- a/protocol/osrs-223/osrs-223-shared/src/main/kotlin/net/rsprot/protocol/common/js5/outgoing/codec/Js5GroupResponseEncoder.kt
+++ b/protocol/osrs-223/osrs-223-shared/src/main/kotlin/net/rsprot/protocol/common/js5/outgoing/codec/Js5GroupResponseEncoder.kt
@@ -17,7 +17,7 @@ public class Js5GroupResponseEncoder : MessageEncoder<Js5GroupResponse> {
         message: Js5GroupResponse,
     ) {
         val offset = message.offset
-        val limit = message.limit
+        val length = message.length
         val messageBuf = message.content()
         // Perform a quick one-time validation to ensure the server is yielding the same
         // type bytebuffers that the Netty pipeline is expecting, to avoid very expensive
@@ -39,14 +39,14 @@ public class Js5GroupResponseEncoder : MessageEncoder<Js5GroupResponse> {
         }
         if (message.key != 0) {
             val out = buffer.buffer
-            for (i in offset..<limit) {
-                out.writeByte(messageBuf.getByte(i).toInt() xor message.key)
+            for (i in 0..<length) {
+                out.writeByte(messageBuf.getByte(offset + i).toInt() xor message.key)
             }
         } else {
             buffer.buffer.writeBytes(
                 messageBuf,
                 offset,
-                limit,
+                length,
             )
         }
     }

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/js5/outgoing/Js5GroupResponse.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/js5/outgoing/Js5GroupResponse.kt
@@ -8,12 +8,12 @@ import net.rsprot.protocol.message.OutgoingJs5Message
  * Js5 group responses are used to feed the cache to the client through the server.
  * @param buffer the byte buffer that is used for the response
  * @property offset the starting index from which the response is written
- * @property limit the ending index until which the response is written
+ * @property length the length of the message to be written
  */
 public class Js5GroupResponse(
     buffer: ByteBuf,
     public val offset: Int,
-    public val limit: Int,
+    public val length: Int,
     public val key: Int,
 ) : DefaultByteBufHolder(buffer),
     OutgoingJs5Message {
@@ -25,7 +25,7 @@ public class Js5GroupResponse(
         other as Js5GroupResponse
 
         if (offset != other.offset) return false
-        if (limit != other.limit) return false
+        if (length != other.length) return false
 
         return true
     }
@@ -33,13 +33,13 @@ public class Js5GroupResponse(
     override fun hashCode(): Int {
         var result = super.hashCode()
         result = 31 * result + offset
-        result = 31 * result + limit
+        result = 31 * result + length
         return result
     }
 
     override fun toString(): String =
         "Js5GroupResponse(" +
             "offset=$offset, " +
-            "limit=$limit" +
+            "length=$length" +
             ")"
 }

--- a/protocol/osrs-224/osrs-224-shared/src/main/kotlin/net/rsprot/protocol/common/js5/outgoing/codec/Js5GroupResponseEncoder.kt
+++ b/protocol/osrs-224/osrs-224-shared/src/main/kotlin/net/rsprot/protocol/common/js5/outgoing/codec/Js5GroupResponseEncoder.kt
@@ -17,7 +17,7 @@ public class Js5GroupResponseEncoder : MessageEncoder<Js5GroupResponse> {
         message: Js5GroupResponse,
     ) {
         val offset = message.offset
-        val limit = message.limit
+        val length = message.length
         val messageBuf = message.content()
         // Perform a quick one-time validation to ensure the server is yielding the same
         // type bytebuffers that the Netty pipeline is expecting, to avoid very expensive
@@ -39,14 +39,14 @@ public class Js5GroupResponseEncoder : MessageEncoder<Js5GroupResponse> {
         }
         if (message.key != 0) {
             val out = buffer.buffer
-            for (i in offset..<limit) {
-                out.writeByte(messageBuf.getByte(i).toInt() xor message.key)
+            for (i in 0..<length) {
+                out.writeByte(messageBuf.getByte(offset + i).toInt() xor message.key)
             }
         } else {
             buffer.buffer.writeBytes(
                 messageBuf,
                 offset,
-                limit,
+                length,
             )
         }
     }

--- a/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/NetworkService.kt
+++ b/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/NetworkService.kt
@@ -12,6 +12,7 @@ import net.rsprot.protocol.api.handlers.ExceptionHandlers
 import net.rsprot.protocol.api.handlers.GameMessageHandlers
 import net.rsprot.protocol.api.handlers.INetAddressHandlers
 import net.rsprot.protocol.api.handlers.LoginHandlers
+import net.rsprot.protocol.api.handlers.OutgoingMessageSizeEstimator
 import net.rsprot.protocol.api.js5.Js5Configuration
 import net.rsprot.protocol.api.js5.Js5GroupProvider
 import net.rsprot.protocol.api.js5.Js5Service
@@ -119,6 +120,8 @@ public class NetworkService<R>
             get() = entityInfoProtocols.worldEntityAvatarFactory
         public val worldEntityInfoProtocol: WorldEntityProtocol
             get() = entityInfoProtocols.worldEntityInfoProtocol
+        public val messageSizeEstimator: OutgoingMessageSizeEstimator =
+            OutgoingMessageSizeEstimator(encoderRepositories)
 
         private lateinit var bossGroup: EventLoopGroup
         private lateinit var childGroup: EventLoopGroup
@@ -133,7 +136,7 @@ public class NetworkService<R>
         public fun start() {
             val time =
                 measureTime {
-                    val bootstrap = bootstrapBuilder.build(this)
+                    val bootstrap = bootstrapBuilder.build(messageSizeEstimator)
                     val initializer =
                         bootstrap.childHandler(
                             LoginChannelInitializer(this),

--- a/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/NetworkService.kt
+++ b/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/NetworkService.kt
@@ -133,7 +133,7 @@ public class NetworkService<R>
         public fun start() {
             val time =
                 measureTime {
-                    val bootstrap = bootstrapBuilder.build()
+                    val bootstrap = bootstrapBuilder.build(this)
                     val initializer =
                         bootstrap.childHandler(
                             LoginChannelInitializer(this),

--- a/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/bootstrap/BootstrapBuilder.kt
+++ b/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/bootstrap/BootstrapBuilder.kt
@@ -20,7 +20,6 @@ import io.netty.channel.socket.nio.NioServerSocketChannel
 import io.netty.incubator.channel.uring.IOUring
 import io.netty.incubator.channel.uring.IOUringEventLoopGroup
 import io.netty.incubator.channel.uring.IOUringServerSocketChannel
-import net.rsprot.protocol.api.NetworkService
 import net.rsprot.protocol.api.handlers.OutgoingMessageSizeEstimator
 import java.text.NumberFormat
 import kotlin.math.max
@@ -283,7 +282,7 @@ public class BootstrapBuilder {
     /**
      * Builds the server bootstrap based on the criteria given through the builder.
      */
-    internal fun build(service: NetworkService<*>): ServerBootstrap {
+    internal fun build(estimator: OutgoingMessageSizeEstimator): ServerBootstrap {
         val bootstrap = ServerBootstrap()
         val groupTypes = getEventLoopGroupTypes()
         val bossThreadCount = determineBossThreadCount()
@@ -330,10 +329,7 @@ public class BootstrapBuilder {
         val tcpNoDelay = this.tcpNoDelay != false
         bootstrap.childOption(ChannelOption.TCP_NODELAY, tcpNoDelay)
         log { "Nagle's algorithm (TCP no delay): ${if (tcpNoDelay) "disabled" else "enabled"}" }
-        bootstrap.childOption(
-            ChannelOption.MESSAGE_SIZE_ESTIMATOR,
-            OutgoingMessageSizeEstimator(service),
-        )
+        bootstrap.childOption(ChannelOption.MESSAGE_SIZE_ESTIMATOR, estimator)
         if (bossGroup is EpollEventLoopGroup) {
             bootstrap.childOption(EpollChannelOption.EPOLL_MODE, EpollMode.LEVEL_TRIGGERED)
             log { "Using level-triggered Epoll mode." }

--- a/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/bootstrap/BootstrapBuilder.kt
+++ b/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/bootstrap/BootstrapBuilder.kt
@@ -20,6 +20,8 @@ import io.netty.channel.socket.nio.NioServerSocketChannel
 import io.netty.incubator.channel.uring.IOUring
 import io.netty.incubator.channel.uring.IOUringEventLoopGroup
 import io.netty.incubator.channel.uring.IOUringServerSocketChannel
+import net.rsprot.protocol.api.NetworkService
+import net.rsprot.protocol.api.handlers.OutgoingMessageSizeEstimator
 import java.text.NumberFormat
 import kotlin.math.max
 
@@ -281,7 +283,7 @@ public class BootstrapBuilder {
     /**
      * Builds the server bootstrap based on the criteria given through the builder.
      */
-    internal fun build(): ServerBootstrap {
+    internal fun build(service: NetworkService<*>): ServerBootstrap {
         val bootstrap = ServerBootstrap()
         val groupTypes = getEventLoopGroupTypes()
         val bossThreadCount = determineBossThreadCount()
@@ -328,6 +330,10 @@ public class BootstrapBuilder {
         val tcpNoDelay = this.tcpNoDelay != false
         bootstrap.childOption(ChannelOption.TCP_NODELAY, tcpNoDelay)
         log { "Nagle's algorithm (TCP no delay): ${if (tcpNoDelay) "disabled" else "enabled"}" }
+        bootstrap.childOption(
+            ChannelOption.MESSAGE_SIZE_ESTIMATOR,
+            OutgoingMessageSizeEstimator(service),
+        )
         if (bossGroup is EpollEventLoopGroup) {
             bootstrap.childOption(EpollChannelOption.EPOLL_MODE, EpollMode.LEVEL_TRIGGERED)
             log { "Using level-triggered Epoll mode." }

--- a/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/encoder/OutgoingMessageEncoder.kt
+++ b/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/encoder/OutgoingMessageEncoder.kt
@@ -91,7 +91,7 @@ public abstract class OutgoingMessageEncoder : ChannelOutboundHandlerAdapter() {
     ) where T : OutgoingMessage, T : ByteBufHolder {
         writePacketHeader(ctx, msg)
 
-        val bufHolderContent = msg.content()
+        val bufHolderContent = msg.content().slice()
         // If there are trailing bytes, we need to encode and write those as well
         if (msg is ByteBufHolderWrapperFooterMessage) {
             // If the byte buf holder wrapper is a footer, use void promise as we don't

--- a/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/encoder/OutgoingMessageEncoder.kt
+++ b/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/encoder/OutgoingMessageEncoder.kt
@@ -140,6 +140,7 @@ public abstract class OutgoingMessageEncoder : ChannelOutboundHandlerAdapter() {
             Prot.VAR_BYTE -> headerSize += Byte.SIZE_BYTES
             Prot.VAR_SHORT -> headerSize += Short.SIZE_BYTES
         }
+        val excludedLoggingSize = headerSize
         if (msg is ByteBufHolderWrapperHeaderMessage) {
             headerSize += msg.nonByteBufHolderSize()
         }
@@ -161,8 +162,10 @@ public abstract class OutgoingMessageEncoder : ChannelOutboundHandlerAdapter() {
             if (msg is ByteBufHolderWrapperHeaderMessage) {
                 encodePayload(msg, buf)
             }
+            val size = headerSize - excludedLoggingSize
             ctx.write(buf, ctx.voidPromise())
             buf = null
+            onMessageWritten(ctx, opcode, size)
         } finally {
             buf?.release()
         }

--- a/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/encoder/OutgoingMessageEncoder.kt
+++ b/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/encoder/OutgoingMessageEncoder.kt
@@ -2,8 +2,13 @@ package net.rsprot.protocol.api.encoder
 
 import com.github.michaelbull.logging.InlineLogger
 import io.netty.buffer.ByteBuf
+import io.netty.buffer.ByteBufHolder
+import io.netty.buffer.Unpooled
 import io.netty.channel.ChannelHandlerContext
-import io.netty.handler.codec.MessageToByteEncoder
+import io.netty.channel.ChannelOutboundHandlerAdapter
+import io.netty.channel.ChannelPromise
+import io.netty.handler.codec.EncoderException
+import io.netty.util.ReferenceCountUtil
 import net.rsprot.buffer.extensions.p1
 import net.rsprot.buffer.extensions.p2
 import net.rsprot.buffer.extensions.toJagByteBuf
@@ -11,6 +16,8 @@ import net.rsprot.crypto.cipher.StreamCipher
 import net.rsprot.protocol.Prot
 import net.rsprot.protocol.api.handlers.OutgoingMessageSizeEstimator
 import net.rsprot.protocol.loginprot.outgoing.LoginResponse
+import net.rsprot.protocol.message.ByteBufHolderWrapperFooterMessage
+import net.rsprot.protocol.message.ByteBufHolderWrapperHeaderMessage
 import net.rsprot.protocol.message.OutgoingMessage
 import net.rsprot.protocol.message.codec.outgoing.MessageEncoderRepository
 
@@ -20,13 +27,160 @@ import net.rsprot.protocol.message.codec.outgoing.MessageEncoderRepository
  * some packets, the entire payload
  * @property repository the message encoder repository containing all the encoders
  */
-public abstract class OutgoingMessageEncoder : MessageToByteEncoder<OutgoingMessage>(OutgoingMessage::class.java) {
+public abstract class OutgoingMessageEncoder : ChannelOutboundHandlerAdapter() {
     protected abstract val cipher: StreamCipher
     protected abstract val repository: MessageEncoderRepository<*>
     protected abstract val validate: Boolean
     protected abstract val estimator: OutgoingMessageSizeEstimator
 
-    override fun encode(
+    override fun write(
+        ctx: ChannelHandlerContext,
+        msg: Any,
+        promise: ChannelPromise,
+    ) {
+        if (msg !is OutgoingMessage) {
+            ctx.write(msg, promise)
+            return
+        }
+        try {
+            if (msg is ByteBufHolder) {
+                writeByteBufHolderMessage(ctx, msg, promise)
+            } else {
+                writeRegularMessage(ctx, msg, promise)
+            }
+        } catch (e: EncoderException) {
+            throw e
+        } catch (t: Throwable) {
+            throw EncoderException(t)
+        }
+    }
+
+    private fun writeRegularMessage(
+        ctx: ChannelHandlerContext,
+        msg: OutgoingMessage,
+        promise: ChannelPromise,
+    ) {
+        var buf: ByteBuf? = null
+        try {
+            try {
+                buf = allocateBuffer(ctx, msg)
+                encode(ctx, msg, buf)
+            } finally {
+                ReferenceCountUtil.release(msg)
+            }
+            // IntelliJ and gradle seem to disagree about this being nullable...
+            @Suppress("SENSELESS_COMPARISON")
+            if (buf != null) {
+                if (buf.isReadable) {
+                    ctx.write(buf, promise)
+                } else {
+                    buf.release()
+                    ctx.write(Unpooled.EMPTY_BUFFER, promise)
+                }
+            }
+            buf = null
+        } finally {
+            buf?.release()
+        }
+    }
+
+    private fun <T> writeByteBufHolderMessage(
+        ctx: ChannelHandlerContext,
+        msg: T,
+        promise: ChannelPromise,
+    ) where T : OutgoingMessage, T : ByteBufHolder {
+        writePacketHeader(ctx, msg)
+
+        val bufHolderContent = msg.content()
+        // If there are trailing bytes, we need to encode and write those as well
+        if (msg is ByteBufHolderWrapperFooterMessage) {
+            // If the byte buf holder wrapper is a footer, use void promise as we don't
+            // want to complete the promise until the last bytes of this packet have been written,
+            // which would be represented by the footer
+            if (bufHolderContent.isReadable) {
+                ctx.write(bufHolderContent, ctx.voidPromise())
+            } else {
+                bufHolderContent.release()
+                ctx.write(Unpooled.EMPTY_BUFFER, ctx.voidPromise())
+            }
+
+            var footer: ByteBuf? = null
+            try {
+                footer = allocateBuffer(ctx, msg.nonByteBufHolderSize())
+                encodePayload(msg, footer)
+                if (footer.isReadable) {
+                    ctx.write(footer, promise)
+                } else {
+                    footer.release()
+                    ctx.write(Unpooled.EMPTY_BUFFER, promise)
+                }
+                footer = null
+            } finally {
+                footer?.release()
+            }
+        } else {
+            if (bufHolderContent.isReadable) {
+                ctx.write(bufHolderContent, promise)
+            } else {
+                bufHolderContent.release()
+                ctx.write(Unpooled.EMPTY_BUFFER, promise)
+            }
+        }
+    }
+
+    private fun <T> writePacketHeader(
+        ctx: ChannelHandlerContext,
+        msg: T,
+    ) where T : OutgoingMessage, T : ByteBufHolder {
+        val encoder = repository.getEncoder(msg::class.java)
+        val prot = encoder.prot
+        val opcode = prot.opcode
+        var headerSize = if (opcode >= 0x80) Short.SIZE_BYTES else Byte.SIZE_BYTES
+        when (prot.size) {
+            Prot.VAR_BYTE -> headerSize += Byte.SIZE_BYTES
+            Prot.VAR_SHORT -> headerSize += Short.SIZE_BYTES
+        }
+        if (msg is ByteBufHolderWrapperHeaderMessage) {
+            headerSize += msg.nonByteBufHolderSize()
+        }
+        var buf: ByteBuf? = null
+        try {
+            buf = ctx.alloc().ioBuffer(headerSize)
+            pSmart1Or2Enc(buf, opcode)
+            var bytes = msg.content().readableBytes()
+            if (msg is ByteBufHolderWrapperHeaderMessage) {
+                bytes += msg.nonByteBufHolderSize()
+            }
+            if (msg is ByteBufHolderWrapperFooterMessage) {
+                bytes += msg.nonByteBufHolderSize()
+            }
+            when (prot.size) {
+                Prot.VAR_BYTE -> buf.p1(bytes)
+                Prot.VAR_SHORT -> buf.p2(bytes)
+            }
+            if (msg is ByteBufHolderWrapperHeaderMessage) {
+                encodePayload(msg, buf)
+            }
+            ctx.write(buf, ctx.voidPromise())
+            buf = null
+        } finally {
+            buf?.release()
+        }
+    }
+
+    private fun encodePayload(
+        msg: OutgoingMessage,
+        out: ByteBuf,
+    ) {
+        val encoder = repository.getEncoder(msg::class.java)
+        encoder.encode(
+            cipher,
+            out.toJagByteBuf(),
+            msg,
+        )
+    }
+
+    protected open fun encode(
         ctx: ChannelHandlerContext,
         msg: OutgoingMessage,
         out: ByteBuf,
@@ -163,17 +317,19 @@ public abstract class OutgoingMessageEncoder : MessageToByteEncoder<OutgoingMess
         }
     }
 
-    override fun allocateBuffer(
+    protected fun allocateBuffer(
         ctx: ChannelHandlerContext,
         msg: OutgoingMessage,
-        preferDirect: Boolean,
-    ): ByteBuf? {
+    ): ByteBuf {
         val size = estimator.newHandle().size(msg)
-        return if (preferDirect) {
-            ctx.alloc().ioBuffer(size)
-        } else {
-            ctx.alloc().heapBuffer(size)
-        }
+        return ctx.alloc().ioBuffer(size)
+    }
+
+    private fun allocateBuffer(
+        ctx: ChannelHandlerContext,
+        cap: Int,
+    ): ByteBuf {
+        return ctx.alloc().ioBuffer(cap)
     }
 
     private companion object {

--- a/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/game/GameMessageEncoder.kt
+++ b/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/game/GameMessageEncoder.kt
@@ -5,6 +5,7 @@ import net.rsprot.crypto.cipher.StreamCipher
 import net.rsprot.protocol.api.NetworkService
 import net.rsprot.protocol.api.channel.inetAddress
 import net.rsprot.protocol.api.encoder.OutgoingMessageEncoder
+import net.rsprot.protocol.api.handlers.OutgoingMessageSizeEstimator
 import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.message.codec.outgoing.MessageEncoderRepository
 
@@ -19,6 +20,7 @@ public class GameMessageEncoder(
     override val repository: MessageEncoderRepository<*> =
         networkService.encoderRepositories.gameMessageDecoderRepositories[client]
     override val validate: Boolean = true
+    override val estimator: OutgoingMessageSizeEstimator = networkService.messageSizeEstimator
 
     override fun onMessageWritten(
         ctx: ChannelHandlerContext,

--- a/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/handlers/OutgoingMessageSizeEstimator.kt
+++ b/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/handlers/OutgoingMessageSizeEstimator.kt
@@ -7,7 +7,7 @@ import io.netty.channel.FileRegion
 import io.netty.channel.MessageSizeEstimator
 import net.rsprot.protocol.Prot
 import net.rsprot.protocol.ServerProt
-import net.rsprot.protocol.api.NetworkService
+import net.rsprot.protocol.api.repositories.MessageEncoderRepositories
 import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.message.OutgoingGameMessage
 import net.rsprot.protocol.message.OutgoingJs5Message
@@ -15,20 +15,17 @@ import net.rsprot.protocol.message.OutgoingLoginMessage
 import net.rsprot.protocol.message.OutgoingMessage
 
 public class OutgoingMessageSizeEstimator(
-    networkService: NetworkService<*>,
+    repositories: MessageEncoderRepositories,
 ) : MessageSizeEstimator {
     private val supportsMultiplePlatforms =
-        networkService
-            .encoderRepositories
+        repositories
             .gameMessageDecoderRepositories
             .notNullSize > 1
     private val gameEncoder =
-        networkService
-            .encoderRepositories
+        repositories
             .gameMessageDecoderRepositories[ESTIMATOR_CLIENT_TYPE]
     private val loginEncoder =
-        networkService
-            .encoderRepositories
+        repositories
             .loginMessageDecoderRepository
 
     private val singleton = OutgoingMessageSizeEstimatorHandle()

--- a/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/handlers/OutgoingMessageSizeEstimator.kt
+++ b/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/handlers/OutgoingMessageSizeEstimator.kt
@@ -1,0 +1,146 @@
+package net.rsprot.protocol.api.handlers
+
+import com.github.michaelbull.logging.InlineLogger
+import io.netty.buffer.ByteBuf
+import io.netty.buffer.ByteBufHolder
+import io.netty.channel.FileRegion
+import io.netty.channel.MessageSizeEstimator
+import net.rsprot.protocol.Prot
+import net.rsprot.protocol.ServerProt
+import net.rsprot.protocol.api.NetworkService
+import net.rsprot.protocol.common.client.OldSchoolClientType
+import net.rsprot.protocol.message.OutgoingGameMessage
+import net.rsprot.protocol.message.OutgoingJs5Message
+import net.rsprot.protocol.message.OutgoingLoginMessage
+import net.rsprot.protocol.message.OutgoingMessage
+
+public class OutgoingMessageSizeEstimator(
+    networkService: NetworkService<*>,
+) : MessageSizeEstimator {
+    private val supportsMultiplePlatforms =
+        networkService
+            .encoderRepositories
+            .gameMessageDecoderRepositories
+            .notNullSize > 1
+    private val gameEncoder =
+        networkService
+            .encoderRepositories
+            .gameMessageDecoderRepositories[ESTIMATOR_CLIENT_TYPE]
+    private val loginEncoder =
+        networkService
+            .encoderRepositories
+            .loginMessageDecoderRepository
+
+    private val singleton = OutgoingMessageSizeEstimatorHandle()
+
+    override fun newHandle(): MessageSizeEstimator.Handle = singleton
+
+    private inner class OutgoingMessageSizeEstimatorHandle : MessageSizeEstimator.Handle {
+        override fun size(msg: Any): Int {
+            try {
+                when (msg) {
+                    is OutgoingGameMessage -> {
+                        return estimateGameMessageSize(msg)
+                    }
+                    is OutgoingLoginMessage -> {
+                        return estimateLoginMessageSize(msg)
+                    }
+                    is OutgoingJs5Message -> {
+                        return estimateJs5MessageSize(msg)
+                    }
+                }
+                if (msg is ByteBuf) {
+                    return msg.readableBytes()
+                }
+                if (msg is ByteBufHolder) {
+                    return msg.content().readableBytes()
+                }
+                if (msg is FileRegion) {
+                    return FILE_REGION_SIZE
+                }
+                return UNKNOWN_MESSAGE_SIZE
+            } catch (t: Throwable) {
+                logger.error(t) {
+                    "Unable to estimate the size of message $msg"
+                }
+                return UNKNOWN_MESSAGE_SIZE
+            }
+        }
+
+        private fun estimateGameMessageSize(msg: OutgoingGameMessage): Int {
+            val prot = gameEncoder.getEncoder(msg.javaClass).prot
+            return estimateRegularProtocolMessage(msg, prot)
+        }
+
+        private fun estimateLoginMessageSize(msg: OutgoingLoginMessage): Int {
+            val prot = loginEncoder.getEncoder(msg.javaClass).prot
+            return estimateRegularProtocolMessage(msg, prot)
+        }
+
+        private fun estimateJs5MessageSize(msg: OutgoingJs5Message): Int {
+            val estimate = msg.estimateSize()
+            if (estimate != -1) {
+                return estimate
+            }
+            if (msg is ByteBufHolder) {
+                return msg.content().readableBytes()
+            }
+            return UNKNOWN_JS5_MESSAGE_PAYLOAD_SIZE
+        }
+
+        private fun estimateRegularProtocolMessage(
+            msg: OutgoingMessage,
+            prot: ServerProt,
+        ): Int {
+            // First reserve one or two bytes for the opcode, depending on circumstances
+            // If we know there's only the desktop platform registered, we can rely on that
+            // to know if the opcode requires two bytes or one
+            // If multiple platforms are used however, we always just assume two bytes
+            // to avoid the expensive resizing operation
+            var headerSize =
+                if (supportsMultiplePlatforms || prot.opcode >= TWO_BYTE_OPCODE_THRESHOLD) {
+                    Short.SIZE_BYTES
+                } else {
+                    Byte.SIZE_BYTES
+                }
+
+            // Next up, add 1 byte for var-byte and 2 bytes for var-short
+            // If the message is not a var-* one, add the constant size and return early
+            val constantSize = prot.size
+            headerSize +=
+                if (constantSize == Prot.VAR_BYTE) {
+                    Byte.SIZE_BYTES
+                } else if (constantSize == Prot.VAR_SHORT) {
+                    Short.SIZE_BYTES
+                } else {
+                    // If no dynamic payload, return here
+                    return headerSize + constantSize
+                }
+
+            // If we override the estimation, add that to the size and return it
+            val estimate = msg.estimateSize()
+            if (estimate != -1) {
+                return headerSize + estimate
+            }
+            // If an override was not provided, check if the message is a byte buf holder which
+            // will already tell is the exact size of the message
+            if (msg is ByteBufHolder) {
+                return headerSize + msg.content().readableBytes()
+            }
+
+            // If all else fails, just assume the payload size is 8 bytes.
+            // We should try to avoid reaching this stage as it could be off quite a lot
+            return headerSize + UNKNOWN_GAME_MESSAGE_PAYLOAD_SIZE
+        }
+    }
+
+    private companion object {
+        private val ESTIMATOR_CLIENT_TYPE: OldSchoolClientType = OldSchoolClientType.DESKTOP
+        private const val TWO_BYTE_OPCODE_THRESHOLD: Int = 0x80
+        private const val FILE_REGION_SIZE: Int = 0
+        private const val UNKNOWN_MESSAGE_SIZE: Int = 8
+        private const val UNKNOWN_GAME_MESSAGE_PAYLOAD_SIZE: Int = 8
+        private const val UNKNOWN_JS5_MESSAGE_PAYLOAD_SIZE: Int = 512
+        private val logger = InlineLogger()
+    }
+}

--- a/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/handlers/OutgoingMessageSizeEstimator.kt
+++ b/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/handlers/OutgoingMessageSizeEstimator.kt
@@ -130,7 +130,7 @@ public class OutgoingMessageSizeEstimator(
 
             // If all else fails, just assume the payload size is 8 bytes.
             // We should try to avoid reaching this stage as it could be off quite a lot
-            return headerSize + UNKNOWN_GAME_MESSAGE_PAYLOAD_SIZE
+            return headerSize + UNKNOWN_MESSAGE_SIZE
         }
     }
 
@@ -139,7 +139,6 @@ public class OutgoingMessageSizeEstimator(
         private const val TWO_BYTE_OPCODE_THRESHOLD: Int = 0x80
         private const val FILE_REGION_SIZE: Int = 0
         private const val UNKNOWN_MESSAGE_SIZE: Int = 8
-        private const val UNKNOWN_GAME_MESSAGE_PAYLOAD_SIZE: Int = 8
         private const val UNKNOWN_JS5_MESSAGE_PAYLOAD_SIZE: Int = 512
         private val logger = InlineLogger()
     }

--- a/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/js5/Js5Client.kt
+++ b/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/js5/Js5Client.kt
@@ -126,9 +126,7 @@ public class Js5Client(
             writtenGroupCount++
         }
         return Js5GroupResponse(
-            block,
-            progress,
-            length,
+            block.slice(progress, length),
             xorKey,
         )
     }

--- a/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/js5/Js5MessageEncoder.kt
+++ b/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/js5/Js5MessageEncoder.kt
@@ -1,7 +1,11 @@
 package net.rsprot.protocol.api.js5
 
 import io.netty.buffer.ByteBuf
+import io.netty.buffer.Unpooled
 import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.ChannelPromise
+import io.netty.handler.codec.EncoderException
+import io.netty.util.ReferenceCountUtil
 import net.rsprot.buffer.extensions.toJagByteBuf
 import net.rsprot.crypto.cipher.NopStreamCipher
 import net.rsprot.crypto.cipher.StreamCipher
@@ -10,6 +14,7 @@ import net.rsprot.protocol.api.channel.inetAddress
 import net.rsprot.protocol.api.encoder.OutgoingMessageEncoder
 import net.rsprot.protocol.api.handlers.OutgoingMessageSizeEstimator
 import net.rsprot.protocol.common.js5.outgoing.prot.Js5ServerProt
+import net.rsprot.protocol.js5.outgoing.Js5GroupResponse
 import net.rsprot.protocol.message.OutgoingMessage
 import net.rsprot.protocol.message.codec.outgoing.MessageEncoderRepository
 
@@ -24,6 +29,58 @@ public class Js5MessageEncoder(
         networkService.encoderRepositories.js5MessageDecoderRepository
     override val validate: Boolean = false
     override val estimator: OutgoingMessageSizeEstimator = networkService.messageSizeEstimator
+
+    override fun write(
+        ctx: ChannelHandlerContext,
+        msg: Any,
+        promise: ChannelPromise,
+    ) {
+        var buf: ByteBuf? = null
+        try {
+            if (msg is Js5GroupResponse) {
+                if (msg.key != 0) {
+                    // If an encryption key is used, we allocate a new buffer and follow the normal flow
+                    buf = allocateBuffer(ctx, msg)
+                    try {
+                        encode(ctx, msg, buf)
+                    } finally {
+                        ReferenceCountUtil.release(msg)
+                    }
+                    if (buf.isReadable) {
+                        ctx.write(buf, promise)
+                    } else {
+                        buf.release()
+                        ctx.write(Unpooled.EMPTY_BUFFER, promise)
+                    }
+                    buf = null
+                } else {
+                    // If no encryption key is used, we simply pass on the same JS5 byte buffer
+                    // instead of needing to copy it to a new buffer
+                    buf = msg.content()
+
+                    // We _only_ call the encode function to trigger our logging, the function
+                    // itself will not be doing any encoding if key is zero.
+                    encode(ctx, msg, buf)
+
+                    if (buf!!.isReadable) {
+                        ctx.write(buf, promise)
+                    } else {
+                        buf.release()
+                        ctx.write(Unpooled.EMPTY_BUFFER, promise)
+                    }
+                    buf = null
+                }
+            } else {
+                ctx.write(msg, promise)
+            }
+        } catch (e: EncoderException) {
+            throw e
+        } catch (t: Throwable) {
+            throw EncoderException(t)
+        } finally {
+            buf?.release()
+        }
+    }
 
     override fun encode(
         ctx: ChannelHandlerContext,

--- a/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/js5/Js5MessageEncoder.kt
+++ b/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/js5/Js5MessageEncoder.kt
@@ -8,6 +8,7 @@ import net.rsprot.crypto.cipher.StreamCipher
 import net.rsprot.protocol.api.NetworkService
 import net.rsprot.protocol.api.channel.inetAddress
 import net.rsprot.protocol.api.encoder.OutgoingMessageEncoder
+import net.rsprot.protocol.api.handlers.OutgoingMessageSizeEstimator
 import net.rsprot.protocol.common.js5.outgoing.prot.Js5ServerProt
 import net.rsprot.protocol.message.OutgoingMessage
 import net.rsprot.protocol.message.codec.outgoing.MessageEncoderRepository
@@ -22,6 +23,7 @@ public class Js5MessageEncoder(
     override val repository: MessageEncoderRepository<*> =
         networkService.encoderRepositories.js5MessageDecoderRepository
     override val validate: Boolean = false
+    override val estimator: OutgoingMessageSizeEstimator = networkService.messageSizeEstimator
 
     override fun encode(
         ctx: ChannelHandlerContext,

--- a/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/login/LoginMessageEncoder.kt
+++ b/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/login/LoginMessageEncoder.kt
@@ -6,6 +6,7 @@ import net.rsprot.crypto.cipher.StreamCipher
 import net.rsprot.protocol.api.NetworkService
 import net.rsprot.protocol.api.channel.inetAddress
 import net.rsprot.protocol.api.encoder.OutgoingMessageEncoder
+import net.rsprot.protocol.api.handlers.OutgoingMessageSizeEstimator
 import net.rsprot.protocol.message.codec.outgoing.MessageEncoderRepository
 
 /**
@@ -18,6 +19,7 @@ public class LoginMessageEncoder(
     override val repository: MessageEncoderRepository<*> =
         networkService.encoderRepositories.loginMessageDecoderRepository
     override val validate: Boolean = false
+    override val estimator: OutgoingMessageSizeEstimator = networkService.messageSizeEstimator
 
     override fun onMessageWritten(
         ctx: ChannelHandlerContext,

--- a/protocol/osrs-225/osrs-225-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/map/RebuildNormalEncoder.kt
+++ b/protocol/osrs-225/osrs-225-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/map/RebuildNormalEncoder.kt
@@ -3,7 +3,6 @@ package net.rsprot.protocol.game.outgoing.codec.map
 import net.rsprot.buffer.JagByteBuf
 import net.rsprot.crypto.cipher.StreamCipher
 import net.rsprot.protocol.ServerProt
-import net.rsprot.protocol.game.outgoing.map.RebuildLogin
 import net.rsprot.protocol.game.outgoing.map.StaticRebuildMessage
 import net.rsprot.protocol.game.outgoing.prot.GameServerProt
 import net.rsprot.protocol.message.codec.MessageEncoder
@@ -18,14 +17,14 @@ public class RebuildNormalEncoder : MessageEncoder<StaticRebuildMessage> {
     ) {
         // We have to use the same encoder as it relies on the prot
         // under the hood to map the encoders down
-        if (message is RebuildLogin) {
-            val gpiInitBlock = message.gpiInitBlock
-            buffer.buffer.writeBytes(
-                gpiInitBlock,
-                gpiInitBlock.readerIndex(),
-                gpiInitBlock.readableBytes(),
-            )
-        }
+        // if (message is RebuildLogin) {
+        //     val gpiInitBlock = message.gpiInitBlock
+        //     buffer.buffer.writeBytes(
+        //         gpiInitBlock,
+        //         gpiInitBlock.readerIndex(),
+        //         gpiInitBlock.readableBytes(),
+        //     )
+        // }
         buffer.p2(message.zoneX)
         buffer.p2Alt3(message.worldArea)
         buffer.p2Alt1(message.zoneZ)

--- a/protocol/osrs-225/osrs-225-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/header/DesktopUpdateZonePartialEnclosedEncoder.kt
+++ b/protocol/osrs-225/osrs-225-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/header/DesktopUpdateZonePartialEnclosedEncoder.kt
@@ -38,11 +38,11 @@ public class DesktopUpdateZonePartialEnclosedEncoder : MessageEncoder<UpdateZone
         buffer.p1(message.zoneZ)
         buffer.p1Alt2(message.zoneX)
         buffer.p1Alt1(message.level)
-        buffer.buffer.writeBytes(
-            message.payload,
-            message.payload.readerIndex(),
-            message.payload.readableBytes(),
-        )
+        // buffer.buffer.writeBytes(
+        //     message.payload,
+        //     message.payload.readerIndex(),
+        //     message.payload.readableBytes(),
+        // )
     }
 
     public companion object : UpdateZonePartialEnclosedCache {

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/clan/ClanChannelDelta.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/clan/ClanChannelDelta.kt
@@ -39,6 +39,15 @@ public class ClanChannelDelta private constructor(
     override val category: ServerProtCategory
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
 
+    override fun estimateSize(): Int {
+        // Always assume the biggest event size, which is 29 bytes
+        return Byte.SIZE_BYTES +
+            Long.SIZE_BYTES +
+            Long.SIZE_BYTES +
+            Byte.SIZE_BYTES +
+            (29 * events.size)
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/clan/ClanChannelFull.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/clan/ClanChannelFull.kt
@@ -3,6 +3,7 @@ package net.rsprot.protocol.game.outgoing.clan
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
 import net.rsprot.protocol.message.OutgoingGameMessage
+import net.rsprot.protocol.message.util.estimateTextSize
 
 /**
  * Clan channel full packets are used to update
@@ -28,6 +29,28 @@ public class ClanChannelFull private constructor(
         get() = _clanType.toInt()
     override val category: ServerProtCategory
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
+
+    override fun estimateSize(): Int {
+        return when (update) {
+            is JoinUpdate -> {
+                val memberPayloadSize =
+                    update.members.size *
+                        (13 + Byte.SIZE_BYTES + Short.SIZE_BYTES + Byte.SIZE_BYTES)
+                Byte.SIZE_BYTES +
+                    Byte.SIZE_BYTES +
+                    Byte.SIZE_BYTES +
+                    Long.SIZE_BYTES +
+                    Long.SIZE_BYTES +
+                    estimateTextSize(update.clanName) +
+                    Byte.SIZE_BYTES +
+                    Byte.SIZE_BYTES +
+                    Byte.SIZE_BYTES +
+                    Short.SIZE_BYTES +
+                    memberPayloadSize
+            }
+            LeaveUpdate -> Byte.SIZE_BYTES
+        }
+    }
 
     override fun toString(): String =
         "ClanChannelFull(" +

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/clan/ClanSettingsDelta.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/clan/ClanSettingsDelta.kt
@@ -10,7 +10,7 @@ import net.rsprot.protocol.message.OutgoingGameMessage
  * @property owner the hash of the owner.
  * As the value of this property is never assigned in the client, but it is compared,
  * this property should always be assigned the value 0.
- * @property updateNum the number of updates this clans settings has had.
+ * @property updateNum the number of updates this clan's settings has had.
  * If the value does not match up, the client will throw an exception!
  */
 public class ClanSettingsDelta private constructor(
@@ -35,6 +35,14 @@ public class ClanSettingsDelta private constructor(
         get() = _clanType.toInt()
     override val category: ServerProtCategory
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
+
+    override fun estimateSize(): Int {
+        // Assume worst case update which is 24 bytes each
+        return Byte.SIZE_BYTES +
+            Long.SIZE_BYTES +
+            Int.SIZE_BYTES +
+            (updates.size * 24)
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/clan/ClanSettingsFull.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/clan/ClanSettingsFull.kt
@@ -3,6 +3,7 @@ package net.rsprot.protocol.game.outgoing.clan
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
 import net.rsprot.protocol.message.OutgoingGameMessage
+import net.rsprot.protocol.message.util.estimateTextSize
 
 /**
  * Clan settings full packet is used to update the clan's primary settings.
@@ -25,6 +26,48 @@ public class ClanSettingsFull private constructor(
         get() = _clanType.toInt()
     override val category: ServerProtCategory
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
+
+    override fun estimateSize(): Int {
+        return when (update) {
+            is JoinUpdate -> {
+                val sizePerAffinedMember =
+                    13 +
+                        Byte.SIZE_BYTES +
+                        Int.SIZE_BYTES +
+                        Short.SIZE_BYTES +
+                        Byte.SIZE_BYTES
+                val settingsSize =
+                    update
+                        .settings
+                        .sumOf { setting ->
+                            when (setting) {
+                                is IntClanSetting -> Int.SIZE_BYTES + Int.SIZE_BYTES
+                                is LongClanSetting -> Int.SIZE_BYTES + Long.SIZE_BYTES
+                                is StringClanSetting -> Int.SIZE_BYTES + estimateTextSize(setting.value)
+                            }
+                        }
+                Byte.SIZE_BYTES +
+                    Byte.SIZE_BYTES +
+                    Byte.SIZE_BYTES +
+                    Int.SIZE_BYTES +
+                    Int.SIZE_BYTES +
+                    Short.SIZE_BYTES +
+                    Byte.SIZE_BYTES +
+                    13 +
+                    Int.SIZE_BYTES +
+                    Byte.SIZE_BYTES +
+                    Byte.SIZE_BYTES +
+                    Byte.SIZE_BYTES +
+                    Byte.SIZE_BYTES +
+                    Byte.SIZE_BYTES +
+                    (update.affinedMembers.size * sizePerAffinedMember) +
+                    (update.bannedMembers.size * 13) +
+                    Short.SIZE_BYTES +
+                    settingsSize
+            }
+            LeaveUpdate -> Byte.SIZE_BYTES
+        }
+    }
 
     override fun toString(): String =
         "ClanSettingsFull(" +

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/clan/MessageClanChannel.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/clan/MessageClanChannel.kt
@@ -3,6 +3,8 @@ package net.rsprot.protocol.game.outgoing.clan
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
 import net.rsprot.protocol.message.OutgoingGameMessage
+import net.rsprot.protocol.message.util.estimateHuffmanEncodedTextSize
+import net.rsprot.protocol.message.util.estimateTextSize
 
 /**
  * Message clan channel is used to send messages within a clan channel
@@ -65,6 +67,15 @@ public class MessageClanChannel private constructor(
         get() = _chatCrownType.toInt()
     override val category: ServerProtCategory
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
+
+    override fun estimateSize(): Int {
+        return Byte.SIZE_BYTES +
+            estimateTextSize(name) +
+            Short.SIZE_BYTES +
+            3 +
+            Byte.SIZE_BYTES +
+            estimateHuffmanEncodedTextSize(message)
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/clan/MessageClanChannelSystem.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/clan/MessageClanChannelSystem.kt
@@ -3,6 +3,7 @@ package net.rsprot.protocol.game.outgoing.clan
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
 import net.rsprot.protocol.message.OutgoingGameMessage
+import net.rsprot.protocol.message.util.estimateHuffmanEncodedTextSize
 
 /**
  * Message clan channel system is used to send system messages
@@ -55,6 +56,13 @@ public class MessageClanChannelSystem private constructor(
         get() = _worldId.toInt()
     override val category: ServerProtCategory
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
+
+    override fun estimateSize(): Int {
+        return Byte.SIZE_BYTES +
+            Short.SIZE_BYTES +
+            3 +
+            estimateHuffmanEncodedTextSize(message)
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/clan/VarClan.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/clan/VarClan.kt
@@ -3,6 +3,7 @@ package net.rsprot.protocol.game.outgoing.clan
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
 import net.rsprot.protocol.message.OutgoingGameMessage
+import net.rsprot.protocol.message.util.estimateTextSize
 
 /**
  * Var clans are used to transmit a variable of a clan to the user.
@@ -30,6 +31,16 @@ public class VarClan private constructor(
         get() = _id.toInt()
     override val category: ServerProtCategory
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
+
+    override fun estimateSize(): Int {
+        val payloadSize =
+            when (value) {
+                is VarClanIntData -> Int.SIZE_BYTES
+                is VarClanLongData -> Long.SIZE_BYTES
+                is VarClanStringData -> Byte.SIZE_BYTES + estimateTextSize(value.value)
+            }
+        return Short.SIZE_BYTES + payloadSize
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/friendchat/MessageFriendChannel.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/friendchat/MessageFriendChannel.kt
@@ -4,6 +4,8 @@ import net.rsprot.compression.Base37
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
 import net.rsprot.protocol.message.OutgoingGameMessage
+import net.rsprot.protocol.message.util.estimateHuffmanEncodedTextSize
+import net.rsprot.protocol.message.util.estimateTextSize
 
 /**
  * Message friendchannel is used to transmit messages within a friend
@@ -67,6 +69,15 @@ public class MessageFriendChannel private constructor(
         get() = _chatCrownType.toInt()
     override val category: ServerProtCategory
         get() = GameServerProtCategory.LOW_PRIORITY_PROT
+
+    override fun estimateSize(): Int {
+        return estimateTextSize(sender) +
+            Long.SIZE_BYTES +
+            Short.SIZE_BYTES +
+            3 +
+            Byte.SIZE_BYTES +
+            estimateHuffmanEncodedTextSize(message)
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/friendchat/UpdateFriendChatChannelFullV1.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/friendchat/UpdateFriendChatChannelFullV1.kt
@@ -16,6 +16,24 @@ public class UpdateFriendChatChannelFullV1(
     override val category: ServerProtCategory
         get() = GameServerProtCategory.LOW_PRIORITY_PROT
 
+    override fun estimateSize(): Int {
+        return when (val update = updateType) {
+            is JoinUpdate -> {
+                val sizePerEntry =
+                    13 +
+                        Short.SIZE_BYTES +
+                        Byte.SIZE_BYTES +
+                        Byte.SIZE_BYTES
+                13 +
+                    Long.SIZE_BYTES +
+                    Byte.SIZE_BYTES +
+                    Byte.SIZE_BYTES +
+                    (update.entries.size * sizePerEntry)
+            }
+            LeaveUpdate -> 0
+        }
+    }
+
     override fun toString(): String = "UpdateFriendChatChannelFullV1(updateType=$updateType)"
 
     public sealed interface UpdateType

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/friendchat/UpdateFriendChatChannelFullV2.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/friendchat/UpdateFriendChatChannelFullV2.kt
@@ -17,6 +17,24 @@ public class UpdateFriendChatChannelFullV2(
     override val category: ServerProtCategory
         get() = GameServerProtCategory.LOW_PRIORITY_PROT
 
+    override fun estimateSize(): Int {
+        return when (val update = updateType) {
+            is JoinUpdate -> {
+                val sizePerEntry =
+                    13 +
+                        Short.SIZE_BYTES +
+                        Byte.SIZE_BYTES +
+                        Byte.SIZE_BYTES
+                13 +
+                    Long.SIZE_BYTES +
+                    Byte.SIZE_BYTES +
+                    (if (update.entries.size >= 0x80) Short.SIZE_BYTES else Byte.SIZE_BYTES) +
+                    (update.entries.size * sizePerEntry)
+            }
+            LeaveUpdate -> 0
+        }
+    }
+
     override fun toString(): String = "UpdateFriendChatChannelFullV2(updateType=$updateType)"
 
     public sealed interface UpdateType

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/friendchat/UpdateFriendChatChannelSingleUser.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/friendchat/UpdateFriendChatChannelSingleUser.kt
@@ -3,6 +3,7 @@ package net.rsprot.protocol.game.outgoing.friendchat
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
 import net.rsprot.protocol.message.OutgoingGameMessage
+import net.rsprot.protocol.message.util.estimateTextSize
 
 /**
  * Update friendchat singleuser is used to perform a change
@@ -17,6 +18,13 @@ public class UpdateFriendChatChannelSingleUser(
 ) : OutgoingGameMessage {
     override val category: ServerProtCategory
         get() = GameServerProtCategory.LOW_PRIORITY_PROT
+
+    override fun estimateSize(): Int {
+        return estimateTextSize(user.name) +
+            Short.SIZE_BYTES +
+            Byte.SIZE_BYTES +
+            (if (user is AddedFriendChatUser) estimateTextSize(user.worldName) else 0)
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/interfaces/IfResync.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/interfaces/IfResync.kt
@@ -33,6 +33,12 @@ public class IfResync private constructor(
     override val category: ServerProtCategory
         get() = GameServerProtCategory.LOW_PRIORITY_PROT
 
+    override fun estimateSize(): Int =
+        Short.SIZE_BYTES +
+            Short.SIZE_BYTES +
+            (subInterfaces.size * (Int.SIZE_BYTES + Short.SIZE_BYTES + Byte.SIZE_BYTES)) +
+            (events.size * (Int.SIZE_BYTES + Short.SIZE_BYTES + Short.SIZE_BYTES + Int.SIZE_BYTES))
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/interfaces/IfSetText.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/interfaces/IfSetText.kt
@@ -3,6 +3,7 @@ package net.rsprot.protocol.game.outgoing.interfaces
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
 import net.rsprot.protocol.message.OutgoingGameMessage
+import net.rsprot.protocol.message.util.estimateTextSize
 import net.rsprot.protocol.util.CombinedId
 
 /**
@@ -34,6 +35,8 @@ public class IfSetText(
         get() = _combinedId.componentId
     override val category: ServerProtCategory
         get() = GameServerProtCategory.LOW_PRIORITY_PROT
+
+    override fun estimateSize(): Int = Int.SIZE_BYTES + estimateTextSize(text)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/inv/UpdateInvFull.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/inv/UpdateInvFull.kt
@@ -94,6 +94,14 @@ public class UpdateInvFull private constructor(
     override val category: ServerProtCategory
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
 
+    override fun estimateSize(): Int {
+        // We always assume the obj counts are >= 255
+        return Int.SIZE_BYTES +
+            Short.SIZE_BYTES +
+            Short.SIZE_BYTES +
+            (capacity * 7)
+    }
+
     /**
      * Gets the bitpacked obj in the [slot] provided.
      * @param slot the slot in the inventory.

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/inv/UpdateInvPartial.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/inv/UpdateInvPartial.kt
@@ -105,6 +105,14 @@ public class UpdateInvPartial private constructor(
     override val category: ServerProtCategory
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
 
+    override fun estimateSize(): Int {
+        // We always assume the worst case here, which would be
+        // 9 bytes per obj added
+        return Int.SIZE_BYTES +
+            Short.SIZE_BYTES +
+            (count * 9)
+    }
+
     /**
      * Gets the bitpacked obj in the [slot] provided.
      * @param slot the slot in the inventory.

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/logout/LogoutTransfer.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/logout/LogoutTransfer.kt
@@ -3,6 +3,7 @@ package net.rsprot.protocol.game.outgoing.logout
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
 import net.rsprot.protocol.message.OutgoingGameMessage
+import net.rsprot.protocol.message.util.estimateTextSize
 
 /**
  * Logout transfer packet is used for world-hopping purposes,
@@ -69,6 +70,12 @@ public class LogoutTransfer private constructor(
         get() = _id.toInt()
     override val category: ServerProtCategory
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
+
+    override fun estimateSize(): Int {
+        return Short.SIZE_BYTES +
+            Int.SIZE_BYTES +
+            estimateTextSize(host)
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/RebuildLogin.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/RebuildLogin.kt
@@ -51,6 +51,14 @@ public class RebuildLogin private constructor(
     override val category: ServerProtCategory
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
 
+    override fun estimateSize(): Int =
+        Short.SIZE_BYTES +
+            Short.SIZE_BYTES +
+            Short.SIZE_BYTES +
+            Short.SIZE_BYTES +
+            (keys.size * (4 * Int.SIZE_BYTES)) +
+            gpiInitBlock.readableBytes()
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/RebuildLogin.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/RebuildLogin.kt
@@ -8,6 +8,7 @@ import net.rsprot.protocol.game.outgoing.GameServerProtCategory
 import net.rsprot.protocol.game.outgoing.info.playerinfo.PlayerInfo
 import net.rsprot.protocol.game.outgoing.map.util.XteaProvider
 import net.rsprot.protocol.game.outgoing.map.util.buildXteaKeyList
+import net.rsprot.protocol.message.ByteBufHolderWrapperFooterMessage
 
 /**
  * Rebuild login is sent as part of the login procedure as the very first packet,
@@ -27,7 +28,8 @@ public class RebuildLogin private constructor(
     override val keys: List<XteaKey>,
     public val gpiInitBlock: ByteBuf,
 ) : DefaultByteBufHolder(gpiInitBlock),
-    StaticRebuildMessage {
+    StaticRebuildMessage,
+    ByteBufHolderWrapperFooterMessage {
     public constructor(
         zoneX: Int,
         zoneZ: Int,
@@ -58,6 +60,14 @@ public class RebuildLogin private constructor(
             Short.SIZE_BYTES +
             (keys.size * (4 * Int.SIZE_BYTES)) +
             gpiInitBlock.readableBytes()
+
+    override fun nonByteBufHolderSize(): Int {
+        return Short.SIZE_BYTES +
+            Short.SIZE_BYTES +
+            Short.SIZE_BYTES +
+            Short.SIZE_BYTES +
+            (keys.size * (4 * Int.SIZE_BYTES))
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/RebuildNormal.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/RebuildNormal.kt
@@ -40,6 +40,13 @@ public class RebuildNormal private constructor(
     override val category: ServerProtCategory
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
 
+    override fun estimateSize(): Int =
+        Short.SIZE_BYTES +
+            Short.SIZE_BYTES +
+            Short.SIZE_BYTES +
+            Short.SIZE_BYTES +
+            (keys.size * (4 * Int.SIZE_BYTES))
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/RebuildRegion.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/RebuildRegion.kt
@@ -48,6 +48,28 @@ public class RebuildRegion private constructor(
     override val category: ServerProtCategory
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
 
+    @Suppress("DuplicatedCode")
+    override fun estimateSize(): Int {
+        val header =
+            Short.SIZE_BYTES +
+                Short.SIZE_BYTES +
+                Byte.SIZE_BYTES
+        val notNullCount = zones.count { zone -> zone != null }
+        val bitCount = (27 * notNullCount) + (zones.size - notNullCount)
+        val bitBufByteCount = (bitCount + 7) ushr 3
+        // While a little wasteful, it is expensive to determine the true
+        // number of bytes necessary since we only transmit xteas for
+        // each referenced mapsquare at most one time
+        // In here, we just assume each zone belongs in a unique mapsquare
+        // The buffers are pooled anyway so it isn't like we're typically
+        // allocating a ton here, just picking a larger buffer out of the pool.
+        val xteaSize = notNullCount * (4 * Int.SIZE_BYTES)
+        return header +
+            Short.SIZE_BYTES +
+            bitBufByteCount +
+            xteaSize
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/RebuildWorldEntity.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/RebuildWorldEntity.kt
@@ -59,6 +59,28 @@ public class RebuildWorldEntity private constructor(
     override val category: ServerProtCategory
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
 
+    @Suppress("DuplicatedCode")
+    override fun estimateSize(): Int {
+        val header =
+            Short.SIZE_BYTES +
+                Short.SIZE_BYTES +
+                Byte.SIZE_BYTES
+        val notNullCount = zones.count { zone -> zone != null }
+        val bitCount = (27 * notNullCount) + (zones.size - notNullCount)
+        val bitBufByteCount = (bitCount + 7) ushr 3
+        // While a little wasteful, it is expensive to determine the true
+        // number of bytes necessary since we only transmit xteas for
+        // each referenced mapsquare at most one time
+        // In here, we just assume each zone belongs in a unique mapsquare
+        // The buffers are pooled anyway so it isn't like we're typically
+        // allocating a ton here, just picking a larger buffer out of the pool.
+        val xteaSize = notNullCount * (4 * Int.SIZE_BYTES)
+        return header +
+            Short.SIZE_BYTES +
+            bitBufByteCount +
+            xteaSize
+    }
+
     /**
      * Zone provider acts as a function to provide all the necessary information
      * needed for rebuild worldentity to function, in the order the client

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/misc/client/HiscoreReply.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/misc/client/HiscoreReply.kt
@@ -3,6 +3,7 @@ package net.rsprot.protocol.game.outgoing.misc.client
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
 import net.rsprot.protocol.message.OutgoingGameMessage
+import net.rsprot.protocol.message.util.estimateTextSize
 
 /**
  * Hiscore reply is a packet used in the enhanced clients to do
@@ -28,6 +29,23 @@ public class HiscoreReply private constructor(
         get() = _requestId.toInt()
     override val category: ServerProtCategory
         get() = GameServerProtCategory.LOW_PRIORITY_PROT
+
+    override fun estimateSize(): Int {
+        return when (response) {
+            is FailedHiscoreReply -> {
+                Byte.SIZE_BYTES + estimateTextSize(response.reason)
+            }
+            is SuccessfulHiscoreReply -> {
+                Byte.SIZE_BYTES +
+                    Byte.SIZE_BYTES +
+                    (response.statResults.size * (Short.SIZE_BYTES + Int.SIZE_BYTES + Int.SIZE_BYTES)) +
+                    Int.SIZE_BYTES +
+                    Long.SIZE_BYTES +
+                    Short.SIZE_BYTES +
+                    (response.activityResults.size * (Short.SIZE_BYTES + Int.SIZE_BYTES + Int.SIZE_BYTES))
+            }
+        }
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/misc/client/SiteSettings.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/misc/client/SiteSettings.kt
@@ -3,6 +3,7 @@ package net.rsprot.protocol.game.outgoing.misc.client
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
 import net.rsprot.protocol.message.OutgoingGameMessage
+import net.rsprot.protocol.message.util.estimateTextSize
 
 /**
  * Site settings packet is used to identify the given client.
@@ -15,6 +16,10 @@ public class SiteSettings(
 ) : OutgoingGameMessage {
     override val category: ServerProtCategory
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
+
+    override fun estimateSize(): Int {
+        return estimateTextSize(settings)
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/misc/client/UrlOpen.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/misc/client/UrlOpen.kt
@@ -3,6 +3,7 @@ package net.rsprot.protocol.game.outgoing.misc.client
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
 import net.rsprot.protocol.message.OutgoingGameMessage
+import net.rsprot.protocol.message.util.estimateTextSize
 
 /**
  * URL open packets are used to open a site on the target's default
@@ -14,6 +15,10 @@ public class UrlOpen(
 ) : OutgoingGameMessage {
     override val category: ServerProtCategory
         get() = GameServerProtCategory.LOW_PRIORITY_PROT
+
+    override fun estimateSize(): Int {
+        return estimateTextSize(url)
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/misc/player/MessageGame.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/misc/player/MessageGame.kt
@@ -3,6 +3,7 @@ package net.rsprot.protocol.game.outgoing.misc.player
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
 import net.rsprot.protocol.message.OutgoingGameMessage
+import net.rsprot.protocol.message.util.estimateTextSize
 
 /**
  * Message game packet is used to send a normal game message in
@@ -89,6 +90,13 @@ public class MessageGame private constructor(
         get() = _type.toInt()
     override val category: ServerProtCategory
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
+
+    override fun estimateSize(): Int {
+        return (if (type >= 0x80) Short.SIZE_BYTES else Byte.SIZE_BYTES) +
+            Byte.SIZE_BYTES +
+            (if (name != null) estimateTextSize(name) else 0) +
+            estimateTextSize(message)
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/misc/player/RunClientScript.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/misc/player/RunClientScript.kt
@@ -4,6 +4,7 @@ import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.common.RSProtFlags
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
 import net.rsprot.protocol.message.OutgoingGameMessage
+import net.rsprot.protocol.message.util.estimateTextSize
 
 /**
  * Run clientscript packet is used to execute a clientscript in the client
@@ -82,6 +83,24 @@ public class RunClientScript : OutgoingGameMessage {
 
     override val category: ServerProtCategory
         get() = GameServerProtCategory.LOW_PRIORITY_PROT
+
+    override fun estimateSize(): Int {
+        var payloadSize = 0
+        // For clientscripts, as they can be so volatile in length,
+        // we calculate an accurate length of the message
+        for (i in (types.size - 1) downTo 0) {
+            val type = types[i]
+            if (type == 's') {
+                estimateTextSize(values[i] as String)
+            } else {
+                payloadSize += Int.SIZE_BYTES
+            }
+        }
+        return types.size +
+            Byte.SIZE_BYTES +
+            payloadSize +
+            Int.SIZE_BYTES
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/misc/player/SetPlayerOp.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/misc/player/SetPlayerOp.kt
@@ -3,6 +3,7 @@ package net.rsprot.protocol.game.outgoing.misc.player
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
 import net.rsprot.protocol.message.OutgoingGameMessage
+import net.rsprot.protocol.message.util.estimateTextSize
 
 /**
  * Set player op packet is used to set the right-click
@@ -32,6 +33,12 @@ public class SetPlayerOp private constructor(
         get() = _id.toInt()
     override val category: ServerProtCategory
         get() = GameServerProtCategory.LOW_PRIORITY_PROT
+
+    override fun estimateSize(): Int {
+        return Byte.SIZE_BYTES +
+            Byte.SIZE_BYTES +
+            estimateTextSize(op ?: "null")
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/misc/player/UpdateTradingPost.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/misc/player/UpdateTradingPost.kt
@@ -16,6 +16,28 @@ public class UpdateTradingPost(
     override val category: ServerProtCategory
         get() = GameServerProtCategory.LOW_PRIORITY_PROT
 
+    override fun estimateSize(): Int {
+        return when (updateType) {
+            ResetTradingPost -> Byte.SIZE_BYTES
+            is SetTradingPostOfferList -> {
+                val sizePerOffer =
+                    13 +
+                        13 +
+                        Short.SIZE_BYTES +
+                        Long.SIZE_BYTES +
+                        Int.SIZE_BYTES +
+                        Int.SIZE_BYTES
+
+                Byte.SIZE_BYTES +
+                    Long.SIZE_BYTES +
+                    Short.SIZE_BYTES +
+                    Byte.SIZE_BYTES +
+                    Short.SIZE_BYTES +
+                    (updateType.offers.size * sizePerOffer)
+            }
+        }
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/social/MessagePrivate.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/social/MessagePrivate.kt
@@ -3,6 +3,8 @@ package net.rsprot.protocol.game.outgoing.social
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
 import net.rsprot.protocol.message.OutgoingGameMessage
+import net.rsprot.protocol.message.util.estimateHuffmanEncodedTextSize
+import net.rsprot.protocol.message.util.estimateTextSize
 
 /**
  * Message private packets are used to send private messages between
@@ -62,6 +64,13 @@ public class MessagePrivate private constructor(
         get() = _chatCrownType.toInt()
     override val category: ServerProtCategory
         get() = GameServerProtCategory.LOW_PRIORITY_PROT
+
+    override fun estimateSize(): Int =
+        estimateTextSize(sender) +
+            Short.SIZE_BYTES +
+            3 +
+            Byte.SIZE_BYTES +
+            estimateHuffmanEncodedTextSize(message)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/social/MessagePrivateEcho.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/social/MessagePrivateEcho.kt
@@ -3,6 +3,8 @@ package net.rsprot.protocol.game.outgoing.social
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
 import net.rsprot.protocol.message.OutgoingGameMessage
+import net.rsprot.protocol.message.util.estimateHuffmanEncodedTextSize
+import net.rsprot.protocol.message.util.estimateTextSize
 
 /**
  * Message private echo is used to show the messages
@@ -18,6 +20,11 @@ public class MessagePrivateEcho(
 ) : OutgoingGameMessage {
     override val category: ServerProtCategory
         get() = GameServerProtCategory.LOW_PRIORITY_PROT
+
+    override fun estimateSize(): Int {
+        return estimateTextSize(recipient) +
+            estimateHuffmanEncodedTextSize(message)
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/social/UpdateFriendList.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/social/UpdateFriendList.kt
@@ -18,6 +18,26 @@ public class UpdateFriendList(
     override val category: ServerProtCategory
         get() = GameServerProtCategory.LOW_PRIORITY_PROT
 
+    override fun estimateSize(): Int {
+        // In here we assume max len names (and previous names)
+        // but 0 length world name/notes
+        // Even if the world name or notes are used, it would probably
+        // still fall below the allocated size due to the excess allocated
+        // through the name strings
+        val sizePerFriend =
+            Byte.SIZE_BYTES +
+                13 +
+                13 +
+                Short.SIZE_BYTES +
+                Byte.SIZE_BYTES +
+                Byte.SIZE_BYTES +
+                Byte.SIZE_BYTES +
+                Byte.SIZE_BYTES +
+                Int.SIZE_BYTES +
+                Byte.SIZE_BYTES
+        return friends.size * sizePerFriend
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/social/UpdateIgnoreList.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/social/UpdateIgnoreList.kt
@@ -16,6 +16,16 @@ public class UpdateIgnoreList(
     override val category: ServerProtCategory
         get() = GameServerProtCategory.LOW_PRIORITY_PROT
 
+    override fun estimateSize(): Int {
+        // Assume max name/previous name length, and no notes.
+        val sizePerIgnore =
+            Byte.SIZE_BYTES +
+                13 +
+                13 +
+                Byte.SIZE_BYTES
+        return ignores.size * sizePerIgnore
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/header/UpdateZonePartialEnclosed.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/header/UpdateZonePartialEnclosed.kt
@@ -51,6 +51,12 @@ public class UpdateZonePartialEnclosed private constructor(
     override val category: ServerProtCategory
         get() = GameServerProtCategory.HIGH_PRIORITY_PROT
 
+    override fun estimateSize(): Int =
+        Byte.SIZE_BYTES +
+            Byte.SIZE_BYTES +
+            Byte.SIZE_BYTES +
+            payload.readableBytes()
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/header/UpdateZonePartialEnclosed.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/zone/header/UpdateZonePartialEnclosed.kt
@@ -4,6 +4,7 @@ import io.netty.buffer.ByteBuf
 import io.netty.buffer.DefaultByteBufHolder
 import net.rsprot.protocol.ServerProtCategory
 import net.rsprot.protocol.game.outgoing.GameServerProtCategory
+import net.rsprot.protocol.message.ByteBufHolderWrapperHeaderMessage
 import net.rsprot.protocol.message.OutgoingGameMessage
 
 /**
@@ -29,7 +30,8 @@ public class UpdateZonePartialEnclosed private constructor(
     private val _level: UByte,
     public val payload: ByteBuf,
 ) : DefaultByteBufHolder(payload),
-    OutgoingGameMessage {
+    OutgoingGameMessage,
+    ByteBufHolderWrapperHeaderMessage {
     public constructor(
         zoneX: Int,
         zoneZ: Int,
@@ -56,6 +58,12 @@ public class UpdateZonePartialEnclosed private constructor(
             Byte.SIZE_BYTES +
             Byte.SIZE_BYTES +
             payload.readableBytes()
+
+    override fun nonByteBufHolderSize(): Int {
+        return Byte.SIZE_BYTES +
+            Byte.SIZE_BYTES +
+            Byte.SIZE_BYTES
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/js5/outgoing/Js5GroupResponse.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/js5/outgoing/Js5GroupResponse.kt
@@ -7,43 +7,35 @@ import net.rsprot.protocol.message.OutgoingJs5Message
 /**
  * Js5 group responses are used to feed the cache to the client through the server.
  * @param buffer the byte buffer that is used for the response
- * @property offset the starting index from which the response is written
- * @property length the length of the message to be written
  */
 public class Js5GroupResponse(
     buffer: ByteBuf,
-    public val offset: Int,
-    public val length: Int,
     public val key: Int,
 ) : DefaultByteBufHolder(buffer),
     OutgoingJs5Message {
     override fun estimateSize(): Int {
-        return length
+        return content().readableBytes()
     }
 
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-        if (!super.equals(other)) return false
+    override fun equals(o: Any?): Boolean {
+        if (this === o) return true
+        if (o !is Js5GroupResponse) return false
+        if (!super.equals(o)) return false
 
-        other as Js5GroupResponse
-
-        if (offset != other.offset) return false
-        if (length != other.length) return false
+        if (key != o.key) return false
 
         return true
     }
 
     override fun hashCode(): Int {
         var result = super.hashCode()
-        result = 31 * result + offset
-        result = 31 * result + length
+        result = 31 * result + key
         return result
     }
 
-    override fun toString(): String =
-        "Js5GroupResponse(" +
-            "offset=$offset, " +
-            "length=$length" +
+    override fun toString(): String {
+        return "Js5GroupResponse(" +
+            "key=$key" +
             ")"
+    }
 }

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/js5/outgoing/Js5GroupResponse.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/js5/outgoing/Js5GroupResponse.kt
@@ -8,15 +8,19 @@ import net.rsprot.protocol.message.OutgoingJs5Message
  * Js5 group responses are used to feed the cache to the client through the server.
  * @param buffer the byte buffer that is used for the response
  * @property offset the starting index from which the response is written
- * @property limit the ending index until which the response is written
+ * @property length the length of the message to be written
  */
 public class Js5GroupResponse(
     buffer: ByteBuf,
     public val offset: Int,
-    public val limit: Int,
+    public val length: Int,
     public val key: Int,
 ) : DefaultByteBufHolder(buffer),
     OutgoingJs5Message {
+    override fun estimateSize(): Int {
+        return length
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
@@ -25,7 +29,7 @@ public class Js5GroupResponse(
         other as Js5GroupResponse
 
         if (offset != other.offset) return false
-        if (limit != other.limit) return false
+        if (length != other.length) return false
 
         return true
     }
@@ -33,13 +37,13 @@ public class Js5GroupResponse(
     override fun hashCode(): Int {
         var result = super.hashCode()
         result = 31 * result + offset
-        result = 31 * result + limit
+        result = 31 * result + length
         return result
     }
 
     override fun toString(): String =
         "Js5GroupResponse(" +
             "offset=$offset, " +
-            "limit=$limit" +
+            "length=$length" +
             ")"
 }

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/pow/NopProofOfWorkProvider.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/pow/NopProofOfWorkProvider.kt
@@ -18,6 +18,10 @@ public object NopProofOfWorkProvider :
         override fun encode(buffer: JagByteBuf) {
             // nop
         }
+
+        override fun estimateMessageSize(): Int {
+            return 0
+        }
     }
 
     public object NopChallengeMetaData : ChallengeMetaData

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/pow/challenges/ChallengeType.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/pow/challenges/ChallengeType.kt
@@ -20,4 +20,11 @@ public interface ChallengeType<in MetaData : ChallengeMetaData> {
      * @param buffer the buffer into which to encode the challenge
      */
     public fun encode(buffer: JagByteBuf)
+
+    /**
+     * Estimates the size of the message, allowing Netty to accurately track the number of bytes
+     * writing it would require.
+     * @return the number of bytes to initialize with.
+     */
+    public fun estimateMessageSize(): Int
 }

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/pow/challenges/sha256/Sha256Challenge.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/pow/challenges/sha256/Sha256Challenge.kt
@@ -37,6 +37,13 @@ public class Sha256Challenge(
         buffer.pjstr(salt, Charsets.UTF_8)
     }
 
+    override fun estimateMessageSize(): Int {
+        return Byte.SIZE_BYTES +
+            Byte.SIZE_BYTES +
+            salt.length +
+            Byte.SIZE_BYTES
+    }
+
     /**
      * Gets the base string that is part of the input for the hash.
      * A long will be appended to this base string at the end, which will additionally

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/loginprot/outgoing/LoginResponse.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/loginprot/outgoing/LoginResponse.kt
@@ -5,6 +5,7 @@ import io.netty.buffer.DefaultByteBufHolder
 import net.rsprot.protocol.game.outgoing.info.playerinfo.PlayerInfo
 import net.rsprot.protocol.loginprot.outgoing.util.AuthenticatorResponse
 import net.rsprot.protocol.message.OutgoingLoginMessage
+import net.rsprot.protocol.message.util.estimateTextSize
 
 public sealed interface LoginResponse : OutgoingLoginMessage {
     public data class Successful(
@@ -46,6 +47,18 @@ public sealed interface LoginResponse : OutgoingLoginMessage {
             get() = _staffModLevel.toInt()
         public val index: Int
             get() = _index.toInt()
+
+        override fun estimateSize(): Int {
+            return Byte.SIZE_BYTES +
+                Int.SIZE_BYTES +
+                Byte.SIZE_BYTES +
+                Byte.SIZE_BYTES +
+                Short.SIZE_BYTES +
+                Byte.SIZE_BYTES +
+                Long.SIZE_BYTES +
+                Long.SIZE_BYTES +
+                Long.SIZE_BYTES
+        }
 
         override fun toString(): String =
             "Ok(" +
@@ -149,7 +162,13 @@ public sealed interface LoginResponse : OutgoingLoginMessage {
         public val line1: String,
         public val line2: String,
         public val line3: String,
-    ) : LoginResponse
+    ) : LoginResponse {
+        override fun estimateSize(): Int {
+            return estimateTextSize(line1) +
+                estimateTextSize(line2) +
+                estimateTextSize(line3)
+        }
+    }
 
     public data object DisplayNameRequired : LoginResponse
 
@@ -203,7 +222,13 @@ public sealed interface LoginResponse : OutgoingLoginMessage {
 
     public class ProofOfWork(
         public val proofOfWork: net.rsprot.protocol.loginprot.incoming.pow.ProofOfWork<*, *>,
-    ) : LoginResponse
+    ) : LoginResponse {
+        override fun estimateSize(): Int {
+            return proofOfWork
+                .challengeType
+                .estimateMessageSize()
+        }
+    }
 
     public data object DobError : LoginResponse
 

--- a/protocol/osrs-225/osrs-225-shared/src/main/kotlin/net/rsprot/protocol/common/js5/outgoing/codec/Js5GroupResponseEncoder.kt
+++ b/protocol/osrs-225/osrs-225-shared/src/main/kotlin/net/rsprot/protocol/common/js5/outgoing/codec/Js5GroupResponseEncoder.kt
@@ -16,8 +16,6 @@ public class Js5GroupResponseEncoder : MessageEncoder<Js5GroupResponse> {
         buffer: JagByteBuf,
         message: Js5GroupResponse,
     ) {
-        val offset = message.offset
-        val length = message.length
         val messageBuf = message.content()
         // Perform a quick one-time validation to ensure the server is yielding the same
         // type bytebuffers that the Netty pipeline is expecting, to avoid very expensive
@@ -37,17 +35,12 @@ public class Js5GroupResponseEncoder : MessageEncoder<Js5GroupResponse> {
                 logger.debug { "Using compatible JS5 buffer types (direct: $isPipelineDirect)" }
             }
         }
+        // Only write the bytes to the `out` variable if XOR is used
         if (message.key != 0) {
             val out = buffer.buffer
-            for (i in 0..<length) {
-                out.writeByte(messageBuf.getByte(offset + i).toInt() xor message.key)
+            for (i in 0..<messageBuf.readableBytes()) {
+                out.writeByte(messageBuf.getByte(i).toInt() xor message.key)
             }
-        } else {
-            buffer.buffer.writeBytes(
-                messageBuf,
-                offset,
-                length,
-            )
         }
     }
 

--- a/protocol/osrs-225/osrs-225-shared/src/main/kotlin/net/rsprot/protocol/common/js5/outgoing/codec/Js5GroupResponseEncoder.kt
+++ b/protocol/osrs-225/osrs-225-shared/src/main/kotlin/net/rsprot/protocol/common/js5/outgoing/codec/Js5GroupResponseEncoder.kt
@@ -17,7 +17,7 @@ public class Js5GroupResponseEncoder : MessageEncoder<Js5GroupResponse> {
         message: Js5GroupResponse,
     ) {
         val offset = message.offset
-        val limit = message.limit
+        val length = message.length
         val messageBuf = message.content()
         // Perform a quick one-time validation to ensure the server is yielding the same
         // type bytebuffers that the Netty pipeline is expecting, to avoid very expensive
@@ -39,14 +39,14 @@ public class Js5GroupResponseEncoder : MessageEncoder<Js5GroupResponse> {
         }
         if (message.key != 0) {
             val out = buffer.buffer
-            for (i in offset..<limit) {
-                out.writeByte(messageBuf.getByte(i).toInt() xor message.key)
+            for (i in 0..<length) {
+                out.writeByte(messageBuf.getByte(offset + i).toInt() xor message.key)
             }
         } else {
             buffer.buffer.writeBytes(
                 messageBuf,
                 offset,
-                limit,
+                length,
             )
         }
     }

--- a/protocol/osrs-225/osrs-225-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/outgoing/prot/LoginServerProt.kt
+++ b/protocol/osrs-225/osrs-225-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/outgoing/prot/LoginServerProt.kt
@@ -1,5 +1,6 @@
 package net.rsprot.protocol.common.loginprot.outgoing.prot
 
+import net.rsprot.protocol.Prot
 import net.rsprot.protocol.ServerProt
 
 public enum class LoginServerProt(
@@ -7,7 +8,7 @@ public enum class LoginServerProt(
     override val size: Int,
 ) : ServerProt {
     SUCCESSFUL(LoginServerProtId.SUCCESSFUL, 0),
-    OK(LoginServerProtId.OK, -1),
+    OK(LoginServerProtId.OK, Prot.VAR_BYTE),
     INVALID_USERNAME_OR_PASSWORD(LoginServerProtId.INVALID_USERNAME_OR_PASSWORD, 0),
     BANNED(LoginServerProtId.BANNED, 0),
     DUPLICATE(LoginServerProtId.DUPLICATE, 0),
@@ -20,7 +21,7 @@ public enum class LoginServerProt(
     NEED_MEMBERS_ACCOUNT(LoginServerProtId.NEED_MEMBERS_ACCOUNT, 0),
     INVALID_SAVE(LoginServerProtId.INVALID_SAVE, 0),
     UPDATE_IN_PROGRESS(LoginServerProtId.UPDATE_IN_PROGRESS, 0),
-    RECONNECT_OK(LoginServerProtId.RECONNECT_OK, -2),
+    RECONNECT_OK(LoginServerProtId.RECONNECT_OK, Prot.VAR_SHORT),
     TOO_MANY_ATTEMPTS(LoginServerProtId.TOO_MANY_ATTEMPTS, 0),
     IN_MEMBERS_AREA(LoginServerProtId.IN_MEMBERS_AREA, 0),
     LOCKED(LoginServerProtId.LOCKED, 0),
@@ -33,7 +34,7 @@ public enum class LoginServerProt(
     UNKNOWN_REPLY_FROM_LOGINSERVER(LoginServerProtId.UNKNOWN_REPLY_FROM_LOGINSERVER, 0),
     IP_BLOCKED(LoginServerProtId.IP_BLOCKED, 0),
     SERVICE_UNAVAILABLE(LoginServerProtId.SERVICE_UNAVAILABLE, 0),
-    DISALLOWED_BY_SCRIPT(LoginServerProtId.DISALLOWED_BY_SCRIPT, -2),
+    DISALLOWED_BY_SCRIPT(LoginServerProtId.DISALLOWED_BY_SCRIPT, Prot.VAR_SHORT),
     DISPLAYNAME_REQUIRED(LoginServerProtId.DISPLAYNAME_REQUIRED, 0),
     NEGATIVE_CREDIT(LoginServerProtId.NEGATIVE_CREDIT, 0),
     INVALID_SINGLE_SIGNON(LoginServerProtId.INVALID_SINGLE_SIGNON, 0),
@@ -59,7 +60,7 @@ public enum class LoginServerProt(
     LOGIN_FAIL_1(LoginServerProtId.LOGIN_FAIL_1, 0),
     LOGIN_FAIL_2(LoginServerProtId.LOGIN_FAIL_2, 0),
     OUT_OF_DATE_RELOAD(LoginServerProtId.OUT_OF_DATE_RELOAD, 0),
-    PROOF_OF_WORK(LoginServerProtId.PROOF_OF_WORK, -2),
+    PROOF_OF_WORK(LoginServerProtId.PROOF_OF_WORK, Prot.VAR_SHORT),
     DOB_ERROR(LoginServerProtId.DOB_ERROR, 0),
     WEBSITE_DOB(LoginServerProtId.WEBSITE_DOB, 0),
     DOB_REVIEW(LoginServerProtId.DOB_REVIEW, 0),

--- a/protocol/src/main/kotlin/net/rsprot/protocol/message/ByteBufHolderWrapperFooterMessage.kt
+++ b/protocol/src/main/kotlin/net/rsprot/protocol/message/ByteBufHolderWrapperFooterMessage.kt
@@ -1,0 +1,15 @@
+package net.rsprot.protocol.message
+
+/**
+ * A message that notifies our encoder about the byte buf holder packet having
+ * a footer message that needs to be encoded on-top of the content of this message,
+ * at the very end of it.
+ */
+public interface ByteBufHolderWrapperFooterMessage {
+    /**
+     * The number of bytes this message consists of, excluding the buffer that the
+     * byte buf holder itself is carrying.
+     * @return the number of bytes of this message, excluding byte buf holder.
+     */
+    public fun nonByteBufHolderSize(): Int
+}

--- a/protocol/src/main/kotlin/net/rsprot/protocol/message/ByteBufHolderWrapperHeaderMessage.kt
+++ b/protocol/src/main/kotlin/net/rsprot/protocol/message/ByteBufHolderWrapperHeaderMessage.kt
@@ -1,0 +1,14 @@
+package net.rsprot.protocol.message
+
+/**
+ * A message that notifies our encoder about the byte buf holder packet having
+ * a header message that needs to be encoded on-top of the content of this message.
+ */
+public interface ByteBufHolderWrapperHeaderMessage {
+    /**
+     * The number of bytes this message consists of, excluding the buffer that the
+     * byte buf holder itself is carrying.
+     * @return the number of bytes of this message, excluding byte buf holder.
+     */
+    public fun nonByteBufHolderSize(): Int
+}

--- a/protocol/src/main/kotlin/net/rsprot/protocol/message/OutgoingMessage.kt
+++ b/protocol/src/main/kotlin/net/rsprot/protocol/message/OutgoingMessage.kt
@@ -1,3 +1,9 @@
 package net.rsprot.protocol.message
 
-public interface OutgoingMessage : Message
+public interface OutgoingMessage : Message {
+    /**
+     * A function to estimate the size of a message.
+     * The estimate should only consist of the payload, not the header.
+     */
+    public fun estimateSize(): Int = -1
+}

--- a/protocol/src/main/kotlin/net/rsprot/protocol/message/util/MessageSizeEstimatorHelpers.kt
+++ b/protocol/src/main/kotlin/net/rsprot/protocol/message/util/MessageSizeEstimatorHelpers.kt
@@ -1,0 +1,14 @@
+package net.rsprot.protocol.message.util
+
+import net.rsprot.protocol.message.OutgoingMessage
+
+public fun OutgoingMessage.estimateTextSize(text: String): Int {
+    return text.length + Byte.SIZE_BYTES
+}
+
+public fun OutgoingMessage.estimateHuffmanEncodedTextSize(text: String): Int {
+    val worstCaseBitsCount = 22 * text.length
+    val worstCaseByteCount = (worstCaseBitsCount + 7) ushr 3
+    val headerSize = if (text.length >= 0x80) Short.SIZE_BYTES else Byte.SIZE_BYTES
+    return headerSize + worstCaseByteCount
+}


### PR DESCRIPTION
Implements a message size estimator, giving Netty precise information about the size of the buffer that we need to allocate.

The message size estimator is _primarily_ used in the encoder to allocate (or poll from pool) an accurately sized buffer for the message that we need to encode. Netty's default implementation would always allocate a 256-byte sized buffer. If the message that we end up encoding was bigger than that, it would repeatedly resize the buffer, doubling in size each time. This could quickly become costly, especially if the packet is e.g. 15,000 bytes - it would need to be resized 6 times! (256 -> 512 -> 1024 -> 2048 -> 4096 -> 8192 -> 16384)

It is not always viable to accurately estimate the sizes of messages without going over each property, so in those cases, we do a simple calculation to come up with a rough estimate of the maximum possible size for that packet.

In addition to the message size estimator, this PR also rewrites the way we encode our messages in Netty. Instead of using the built-in `MessageToByteEncoder`, we use our own variant. The primary reason for doing this is to avoid copying buffers when the message that we pass to netty is an implementation of the ByteBufHolder itself. Examples of such packets are player_info, npc_info, worldentity_info, update_zone_partial_enclosed, as well as _all_ the outgoing JS5 packets. In a nutshell, all the expensive packets that exist are already pre-calculated and wrapped in a byte buf holder, so all that was previously happening was resizing & copying of the prebuilt packets, which is just unnecessary overhead that reduces our potential throughput.

The custom implementation does not allocate a new byte buffer if the existing one is a byte buf holder, and instead passes the
buffer directly into Netty to be written to the socket. Certain more complex packets, such as update_zone_partial_enclosed also consist of a small header (or footer) on-top of the prebuilt byte buf, in those cases we write the header/footer in a separate tiny buffer and pass that along to netty as a separate message, coming in before or after the prebuilt buffer itself. All the packet headers (opcode and size) are written as the first thing in a separate buffer of its own.