### PR TITLE
fix: documentation within VarpLarge messages

### DIFF
--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/varp/VarpLarge.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/varp/VarpLarge.kt
@@ -5,10 +5,10 @@ import net.rsprot.protocol.game.outgoing.GameServerProtCategory
 import net.rsprot.protocol.message.OutgoingGameMessage
 
 /**
- * Varp small messages are used to send a varp to the client that
+ * Varp large messages are used to send a varp to the client that
  * has a value which does not fit in the range of a byte, being -128..127.
  * For values which do fit in the aforementioned range, the [VarpSmall]
- * packed is preferred as it takes up less bandwidth, although nothing
+ * message is preferred as it takes up less bandwidth, although nothing
  * prevents one from sending all varps using this variant.
  * @property id the id of the varp
  * @property value the value of the varp

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/varp/VarpLarge.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/varp/VarpLarge.kt
@@ -5,10 +5,10 @@ import net.rsprot.protocol.game.outgoing.GameServerProtCategory
 import net.rsprot.protocol.message.OutgoingGameMessage
 
 /**
- * Varp small messages are used to send a varp to the client that
+ * Varp large messages are used to send a varp to the client that
  * has a value which does not fit in the range of a byte, being -128..127.
  * For values which do fit in the aforementioned range, the [VarpSmall]
- * packed is preferred as it takes up less bandwidth, although nothing
+ * message is preferred as it takes up less bandwidth, although nothing
  * prevents one from sending all varps using this variant.
  * @property id the id of the varp
  * @property value the value of the varp

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/varp/VarpLarge.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/varp/VarpLarge.kt
@@ -5,10 +5,10 @@ import net.rsprot.protocol.game.outgoing.GameServerProtCategory
 import net.rsprot.protocol.message.OutgoingGameMessage
 
 /**
- * Varp small messages are used to send a varp to the client that
+ * Varp large messages are used to send a varp to the client that
  * has a value which does not fit in the range of a byte, being -128..127.
  * For values which do fit in the aforementioned range, the [VarpSmall]
- * packed is preferred as it takes up less bandwidth, although nothing
+ * message is preferred as it takes up less bandwidth, although nothing
  * prevents one from sending all varps using this variant.
  * @property id the id of the varp
  * @property value the value of the varp

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/varp/VarpLarge.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/varp/VarpLarge.kt
@@ -5,10 +5,10 @@ import net.rsprot.protocol.game.outgoing.GameServerProtCategory
 import net.rsprot.protocol.message.OutgoingGameMessage
 
 /**
- * Varp small messages are used to send a varp to the client that
+ * Varp large messages are used to send a varp to the client that
  * has a value which does not fit in the range of a byte, being -128..127.
  * For values which do fit in the aforementioned range, the [VarpSmall]
- * packed is preferred as it takes up less bandwidth, although nothing
+ * message is preferred as it takes up less bandwidth, although nothing
  * prevents one from sending all varps using this variant.
  * @property id the id of the varp
  * @property value the value of the varp

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/varp/VarpLarge.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/varp/VarpLarge.kt
@@ -5,10 +5,10 @@ import net.rsprot.protocol.game.outgoing.GameServerProtCategory
 import net.rsprot.protocol.message.OutgoingGameMessage
 
 /**
- * Varp small messages are used to send a varp to the client that
+ * Varp large messages are used to send a varp to the client that
  * has a value which does not fit in the range of a byte, being -128..127.
  * For values which do fit in the aforementioned range, the [VarpSmall]
- * packed is preferred as it takes up less bandwidth, although nothing
+ * message is preferred as it takes up less bandwidth, although nothing
  * prevents one from sending all varps using this variant.
  * @property id the id of the varp
  * @property value the value of the varp

--- a/protocol/osrs-226/osrs-226-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/varp/VarpLarge.kt
+++ b/protocol/osrs-226/osrs-226-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/varp/VarpLarge.kt
@@ -5,10 +5,10 @@ import net.rsprot.protocol.game.outgoing.GameServerProtCategory
 import net.rsprot.protocol.message.OutgoingGameMessage
 
 /**
- * Varp small messages are used to send a varp to the client that
+ * Varp large messages are used to send a varp to the client that
  * has a value which does not fit in the range of a byte, being -128..127.
  * For values which do fit in the aforementioned range, the [VarpSmall]
- * packed is preferred as it takes up less bandwidth, although nothing
+ * message is preferred as it takes up less bandwidth, although nothing
  * prevents one from sending all varps using this variant.
  * @property id the id of the varp
  * @property value the value of the varp


### PR DESCRIPTION
fixes the wording within the varp large packets. 

Also. the term message/packet is used interchangeably within the api. Perhaps this should be standardized in the future? 