### PR TITLE
Zone buffer client mapping

### DIFF
--- a/protocol/osrs-221/osrs-221-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-221/osrs-221-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -164,6 +164,8 @@ public class GameLoginResponseHandler<R>(
                 LoginClientType.ENHANCED_WINDOWS -> OldSchoolClientType.DESKTOP
                 LoginClientType.ENHANCED_LINUX -> OldSchoolClientType.DESKTOP
                 LoginClientType.ENHANCED_MAC -> OldSchoolClientType.DESKTOP
+                LoginClientType.ENHANCED_ANDROID -> OldSchoolClientType.ANDROID
+                LoginClientType.ENHANCED_IOS -> OldSchoolClientType.IOS
                 else -> null
             }
         return oldSchoolClientType

--- a/protocol/osrs-221/osrs-221-common/src/main/kotlin/net/rsprot/protocol/common/client/OldSchoolClientType.kt
+++ b/protocol/osrs-221/osrs-221-common/src/main/kotlin/net/rsprot/protocol/common/client/OldSchoolClientType.kt
@@ -11,6 +11,18 @@ public enum class OldSchoolClientType(
      * we use the same client type for both here.
      */
     DESKTOP(0),
+
+    /**
+     * The Android client.
+     * This is a separate client type as the protocol differs from the desktop clients.
+     */
+    ANDROID(1),
+
+    /**
+     * The iOS client.
+     * This is a separate client type as the protocol differs from the desktop clients.
+     */
+    IOS(2),
     ;
 
     public companion object {
@@ -20,6 +32,6 @@ public enum class OldSchoolClientType(
          * as our buffers are often cached per-client type, and we need to use
          * client types as the array index.
          */
-        public const val COUNT: Int = 1
+        public const val COUNT: Int = 3
     }
 }

--- a/protocol/osrs-221/osrs-221-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/header/DesktopUpdateZonePartialEnclosedEncoder.kt
+++ b/protocol/osrs-221/osrs-221-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/header/DesktopUpdateZonePartialEnclosedEncoder.kt
@@ -63,7 +63,7 @@ public class DesktopUpdateZonePartialEnclosedEncoder : MessageEncoder<UpdateZone
          */
         override fun <T : ZoneProt> buildCache(
             allocator: ByteBufAllocator,
-            messages: List<T>,
+            messages: Collection<T>,
         ): ByteBuf {
             val buffer =
                 allocator

--- a/protocol/osrs-222/osrs-222-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-222/osrs-222-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -163,7 +163,8 @@ public class GameLoginResponseHandler<R>(
                 LoginClientType.DESKTOP -> OldSchoolClientType.DESKTOP
                 LoginClientType.ENHANCED_WINDOWS -> OldSchoolClientType.DESKTOP
                 LoginClientType.ENHANCED_LINUX -> OldSchoolClientType.DESKTOP
-                LoginClientType.ENHANCED_MAC -> OldSchoolClientType.DESKTOP
+                LoginClientType.ENHANCED_ANDROID -> OldSchoolClientType.ANDROID
+                LoginClientType.ENHANCED_IOS -> OldSchoolClientType.IOS
                 else -> null
             }
         return oldSchoolClientType

--- a/protocol/osrs-222/osrs-222-common/src/main/kotlin/net/rsprot/protocol/common/client/OldSchoolClientType.kt
+++ b/protocol/osrs-222/osrs-222-common/src/main/kotlin/net/rsprot/protocol/common/client/OldSchoolClientType.kt
@@ -11,6 +11,18 @@ public enum class OldSchoolClientType(
      * we use the same client type for both here.
      */
     DESKTOP(0),
+
+    /**
+     * The Android client.
+     * This is a separate client type as the protocol differs from the desktop clients.
+     */
+    ANDROID(1),
+
+    /**
+     * The iOS client.
+     * This is a separate client type as the protocol differs from the desktop clients.
+     */
+    IOS(2),
     ;
 
     public companion object {
@@ -20,6 +32,6 @@ public enum class OldSchoolClientType(
          * as our buffers are often cached per-client type, and we need to use
          * client types as the array index.
          */
-        public const val COUNT: Int = 1
+        public const val COUNT: Int = 3
     }
 }

--- a/protocol/osrs-222/osrs-222-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/header/DesktopUpdateZonePartialEnclosedEncoder.kt
+++ b/protocol/osrs-222/osrs-222-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/header/DesktopUpdateZonePartialEnclosedEncoder.kt
@@ -63,7 +63,7 @@ public class DesktopUpdateZonePartialEnclosedEncoder : MessageEncoder<UpdateZone
          */
         override fun <T : ZoneProt> buildCache(
             allocator: ByteBufAllocator,
-            messages: List<T>,
+            messages: Collection<T>,
         ): ByteBuf {
             val buffer =
                 allocator

--- a/protocol/osrs-223/osrs-223-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-223/osrs-223-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -164,6 +164,8 @@ public class GameLoginResponseHandler<R>(
                 LoginClientType.ENHANCED_WINDOWS -> OldSchoolClientType.DESKTOP
                 LoginClientType.ENHANCED_LINUX -> OldSchoolClientType.DESKTOP
                 LoginClientType.ENHANCED_MAC -> OldSchoolClientType.DESKTOP
+                LoginClientType.ENHANCED_ANDROID -> OldSchoolClientType.ANDROID
+                LoginClientType.ENHANCED_IOS -> OldSchoolClientType.IOS
                 else -> null
             }
         return oldSchoolClientType

--- a/protocol/osrs-223/osrs-223-common/src/main/kotlin/net/rsprot/protocol/common/client/OldSchoolClientType.kt
+++ b/protocol/osrs-223/osrs-223-common/src/main/kotlin/net/rsprot/protocol/common/client/OldSchoolClientType.kt
@@ -11,6 +11,18 @@ public enum class OldSchoolClientType(
      * we use the same client type for both here.
      */
     DESKTOP(0),
+
+    /**
+     * The Android client.
+     * This is a separate client type as the protocol differs from the desktop clients.
+     */
+    ANDROID(1),
+
+    /**
+     * The iOS client.
+     * This is a separate client type as the protocol differs from the desktop clients.
+     */
+    IOS(2),
     ;
 
     public companion object {
@@ -20,6 +32,6 @@ public enum class OldSchoolClientType(
          * as our buffers are often cached per-client type, and we need to use
          * client types as the array index.
          */
-        public const val COUNT: Int = 1
+        public const val COUNT: Int = 3
     }
 }

--- a/protocol/osrs-223/osrs-223-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/header/DesktopUpdateZonePartialEnclosedEncoder.kt
+++ b/protocol/osrs-223/osrs-223-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/header/DesktopUpdateZonePartialEnclosedEncoder.kt
@@ -63,7 +63,7 @@ public class DesktopUpdateZonePartialEnclosedEncoder : MessageEncoder<UpdateZone
          */
         override fun <T : ZoneProt> buildCache(
             allocator: ByteBufAllocator,
-            messages: List<T>,
+            messages: Collection<T>,
         ): ByteBuf {
             val buffer =
                 allocator

--- a/protocol/osrs-224/osrs-224-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-224/osrs-224-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -164,6 +164,8 @@ public class GameLoginResponseHandler<R>(
                 LoginClientType.ENHANCED_WINDOWS -> OldSchoolClientType.DESKTOP
                 LoginClientType.ENHANCED_LINUX -> OldSchoolClientType.DESKTOP
                 LoginClientType.ENHANCED_MAC -> OldSchoolClientType.DESKTOP
+                LoginClientType.ENHANCED_ANDROID -> OldSchoolClientType.ANDROID
+                LoginClientType.ENHANCED_IOS -> OldSchoolClientType.IOS
                 else -> null
             }
         return oldSchoolClientType

--- a/protocol/osrs-224/osrs-224-api/src/main/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBuffer.kt
+++ b/protocol/osrs-224/osrs-224-api/src/main/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBuffer.kt
@@ -64,7 +64,7 @@ public class ZonePartialEnclosedCacheBuffer
         private fun <T : ZoneProt> buildZoneProtBuffers(protList: List<T>): EnumMap<OldSchoolClientType, ByteBuf> {
             val map = createClientBufferEnumMap()
             for (client in supportedClients) {
-                val encoder = supportedEncoders[client]
+                val encoder = supportedEncoders.getOrNull(client) ?: continue
                 val buffer = encoder.buildCache(byteBufAllocator, protList)
                 map[client] = buffer
             }

--- a/protocol/osrs-224/osrs-224-api/src/main/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBuffer.kt
+++ b/protocol/osrs-224/osrs-224-api/src/main/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBuffer.kt
@@ -61,6 +61,25 @@ public class ZonePartialEnclosedCacheBuffer
             return clientBuffers
         }
 
+        /**
+         * Computes the expected zone payload **only** for a single [OldSchoolClientType] and returns the corresponding
+         * [ByteBuf].
+         *
+         * Similar to [computeZone], but for a single client rather than all [supportedClients].
+         */
+        public fun <T : ZoneProt> computeZoneForClient(
+            client: OldSchoolClientType,
+            pendingTickProtList: List<T>,
+        ): ByteBuf {
+            val encoder = supportedEncoders[client]
+
+            val buffer = encoder.buildCache(byteBufAllocator, pendingTickProtList)
+            activeCachedBuffers.add(buffer)
+            incrementZoneComputationCount()
+
+            return buffer
+        }
+
         private fun <T : ZoneProt> buildZoneProtBuffers(protList: List<T>): EnumMap<OldSchoolClientType, ByteBuf> {
             val map = createClientBufferEnumMap()
             for (client in supportedClients) {

--- a/protocol/osrs-224/osrs-224-api/src/main/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBuffer.kt
+++ b/protocol/osrs-224/osrs-224-api/src/main/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBuffer.kt
@@ -54,7 +54,9 @@ public class ZonePartialEnclosedCacheBuffer
          * - [net.rsprot.protocol.game.outgoing.zone.payload.ObjEnabledOps]
          * - [net.rsprot.protocol.game.outgoing.zone.payload.SoundArea]
          */
-        public fun <T : ZoneProt> computeZone(pendingTickProtList: List<T>): EnumMap<OldSchoolClientType, ByteBuf> {
+        public fun <T : ZoneProt> computeZone(
+            pendingTickProtList: Collection<T>,
+        ): EnumMap<OldSchoolClientType, ByteBuf> {
             val clientBuffers = buildZoneProtBuffers(pendingTickProtList)
             activeCachedBuffers += clientBuffers.values
             incrementZoneComputationCount()
@@ -69,7 +71,7 @@ public class ZonePartialEnclosedCacheBuffer
          */
         public fun <T : ZoneProt> computeZoneForClient(
             client: OldSchoolClientType,
-            pendingTickProtList: List<T>,
+            pendingTickProtList: Collection<T>,
         ): ByteBuf {
             val encoder = supportedEncoders[client]
 
@@ -80,7 +82,9 @@ public class ZonePartialEnclosedCacheBuffer
             return buffer
         }
 
-        private fun <T : ZoneProt> buildZoneProtBuffers(protList: List<T>): EnumMap<OldSchoolClientType, ByteBuf> {
+        private fun <T : ZoneProt> buildZoneProtBuffers(
+            protList: Collection<T>,
+        ): EnumMap<OldSchoolClientType, ByteBuf> {
             val map = createClientBufferEnumMap()
             for (client in supportedClients) {
                 val encoder = supportedEncoders.getOrNull(client) ?: continue

--- a/protocol/osrs-224/osrs-224-api/src/test/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBufferTest.kt
+++ b/protocol/osrs-224/osrs-224-api/src/test/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBufferTest.kt
@@ -22,17 +22,12 @@ import kotlin.test.Test
 
 class ZonePartialEnclosedCacheBufferTest {
     @Test
-    fun `every available oldschool client type has an associated encoder`() {
-        val encoders = ZonePartialEnclosedCacheBuffer.createEncoderMap()
-        assertEquals(OldSchoolClientType.entries.toSet(), encoders.toClientList().toSet())
-    }
-
-    @Test
     fun `computeZone creates buffers for supported clients`() {
         val cache = ZonePartialEnclosedCacheBuffer()
+        val encoders = ZonePartialEnclosedCacheBuffer.createEncoderMap()
         val buffers = cache.computeZone(emptyList())
 
-        assertEquals(buffers.keys.toSet(), cache.supportedClients.toSet())
+        assertEquals(encoders.toClientList().toSet(), buffers.keys.toSet())
 
         // `computeZone` did not receive any zone prot to encode, so all buffers should be empty.
         val expectedBuffers = buffers.map { Unpooled.wrappedBuffer(ByteArray(0)) }
@@ -43,6 +38,7 @@ class ZonePartialEnclosedCacheBufferTest {
     fun `compute zone partial enclosed buffers`() {
         val cache = ZonePartialEnclosedCacheBuffer()
 
+        val encoders = ZonePartialEnclosedCacheBuffer.createEncoderMap()
         val zoneProt = createFullZoneProtList()
         val buffers = cache.computeZone(zoneProt)
 
@@ -57,7 +53,7 @@ class ZonePartialEnclosedCacheBufferTest {
         }
 
         // Each supported client type should have added a buffer to `activeCachedBuffers`.
-        assertEquals(cache.supportedClients.size, buffers.size)
+        assertEquals(encoders.toClientList().size, buffers.size)
 
         // The leak-reference-counter should have been incremented by a single zone.
         assertEquals(1, cache.currentZoneComputationCount)

--- a/protocol/osrs-224/osrs-224-api/src/test/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBufferTest.kt
+++ b/protocol/osrs-224/osrs-224-api/src/test/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBufferTest.kt
@@ -35,6 +35,31 @@ class ZonePartialEnclosedCacheBufferTest {
     }
 
     @Test
+    fun `computeZoneForClient generates a single buffer for the specified client`() {
+        val cache = ZonePartialEnclosedCacheBuffer()
+        val zoneProt = createFullZoneProtList()
+        val client = OldSchoolClientType.DESKTOP
+
+        val buffer = cache.computeZoneForClient(client, zoneProt)
+
+        // Each zone prot should _at minimum_ write their `indexedEncoder` id. (written as a byte)
+        // Ensuring every zone prot opcode/payload is written correctly falls out of scope for this test.
+        val expectedMinReadableBytes = zoneProt.size * Byte.SIZE_BYTES
+        assertTrue(
+            buffer.readableBytes() >= expectedMinReadableBytes,
+            "Expected `$expectedMinReadableBytes` readable bytes from buffer for client: $client. " +
+                "(bytes=${buffer.readableBytes()})",
+        )
+
+        assertEquals(
+            1,
+            cache.currentZoneComputationCount,
+            "Zone computation should increment by 1 for a single client's buffer.",
+        )
+        assertEquals(1, cache.activeCachedBuffers.size)
+    }
+
+    @Test
     fun `compute zone partial enclosed buffers`() {
         val cache = ZonePartialEnclosedCacheBuffer()
 

--- a/protocol/osrs-224/osrs-224-common/src/main/kotlin/net/rsprot/protocol/common/client/OldSchoolClientType.kt
+++ b/protocol/osrs-224/osrs-224-common/src/main/kotlin/net/rsprot/protocol/common/client/OldSchoolClientType.kt
@@ -11,6 +11,18 @@ public enum class OldSchoolClientType(
      * we use the same client type for both here.
      */
     DESKTOP(0),
+
+    /**
+     * The Android client.
+     * This is a separate client type as the protocol differs from the desktop clients.
+     */
+    ANDROID(1),
+
+    /**
+     * The iOS client.
+     * This is a separate client type as the protocol differs from the desktop clients.
+     */
+    IOS(2),
     ;
 
     public companion object {
@@ -20,6 +32,6 @@ public enum class OldSchoolClientType(
          * as our buffers are often cached per-client type, and we need to use
          * client types as the array index.
          */
-        public const val COUNT: Int = 1
+        public const val COUNT: Int = 3
     }
 }

--- a/protocol/osrs-224/osrs-224-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/header/DesktopUpdateZonePartialEnclosedEncoder.kt
+++ b/protocol/osrs-224/osrs-224-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/header/DesktopUpdateZonePartialEnclosedEncoder.kt
@@ -63,7 +63,7 @@ public class DesktopUpdateZonePartialEnclosedEncoder : MessageEncoder<UpdateZone
          */
         override fun <T : ZoneProt> buildCache(
             allocator: ByteBufAllocator,
-            messages: List<T>,
+            messages: Collection<T>,
         ): ByteBuf {
             val buffer =
                 allocator

--- a/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -184,6 +184,8 @@ public class GameLoginResponseHandler<R>(
                 LoginClientType.ENHANCED_WINDOWS -> OldSchoolClientType.DESKTOP
                 LoginClientType.ENHANCED_LINUX -> OldSchoolClientType.DESKTOP
                 LoginClientType.ENHANCED_MAC -> OldSchoolClientType.DESKTOP
+                LoginClientType.ENHANCED_ANDROID -> OldSchoolClientType.ANDROID
+                LoginClientType.ENHANCED_IOS -> OldSchoolClientType.IOS
                 else -> null
             }
         return oldSchoolClientType

--- a/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBuffer.kt
+++ b/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBuffer.kt
@@ -64,7 +64,7 @@ public class ZonePartialEnclosedCacheBuffer
         private fun <T : ZoneProt> buildZoneProtBuffers(protList: List<T>): EnumMap<OldSchoolClientType, ByteBuf> {
             val map = createClientBufferEnumMap()
             for (client in supportedClients) {
-                val encoder = supportedEncoders[client]
+                val encoder = supportedEncoders.getOrNull(client) ?: continue
                 val buffer = encoder.buildCache(byteBufAllocator, protList)
                 map[client] = buffer
             }

--- a/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBuffer.kt
+++ b/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBuffer.kt
@@ -61,6 +61,25 @@ public class ZonePartialEnclosedCacheBuffer
             return clientBuffers
         }
 
+        /**
+         * Computes the expected zone payload **only** for a single [OldSchoolClientType] and returns the corresponding
+         * [ByteBuf].
+         *
+         * Similar to [computeZone], but for a single client rather than all [supportedClients].
+         */
+        public fun <T : ZoneProt> computeZoneForClient(
+            client: OldSchoolClientType,
+            pendingTickProtList: List<T>,
+        ): ByteBuf {
+            val encoder = supportedEncoders[client]
+
+            val buffer = encoder.buildCache(byteBufAllocator, pendingTickProtList)
+            activeCachedBuffers.add(buffer)
+            incrementZoneComputationCount()
+
+            return buffer
+        }
+
         private fun <T : ZoneProt> buildZoneProtBuffers(protList: List<T>): EnumMap<OldSchoolClientType, ByteBuf> {
             val map = createClientBufferEnumMap()
             for (client in supportedClients) {

--- a/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBuffer.kt
+++ b/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBuffer.kt
@@ -54,7 +54,9 @@ public class ZonePartialEnclosedCacheBuffer
          * - [net.rsprot.protocol.game.outgoing.zone.payload.ObjEnabledOps]
          * - [net.rsprot.protocol.game.outgoing.zone.payload.SoundArea]
          */
-        public fun <T : ZoneProt> computeZone(pendingTickProtList: List<T>): EnumMap<OldSchoolClientType, ByteBuf> {
+        public fun <T : ZoneProt> computeZone(
+            pendingTickProtList: Collection<T>,
+        ): EnumMap<OldSchoolClientType, ByteBuf> {
             val clientBuffers = buildZoneProtBuffers(pendingTickProtList)
             activeCachedBuffers += clientBuffers.values
             incrementZoneComputationCount()
@@ -69,7 +71,7 @@ public class ZonePartialEnclosedCacheBuffer
          */
         public fun <T : ZoneProt> computeZoneForClient(
             client: OldSchoolClientType,
-            pendingTickProtList: List<T>,
+            pendingTickProtList: Collection<T>,
         ): ByteBuf {
             val encoder = supportedEncoders[client]
 
@@ -80,7 +82,9 @@ public class ZonePartialEnclosedCacheBuffer
             return buffer
         }
 
-        private fun <T : ZoneProt> buildZoneProtBuffers(protList: List<T>): EnumMap<OldSchoolClientType, ByteBuf> {
+        private fun <T : ZoneProt> buildZoneProtBuffers(
+            protList: Collection<T>,
+        ): EnumMap<OldSchoolClientType, ByteBuf> {
             val map = createClientBufferEnumMap()
             for (client in supportedClients) {
                 val encoder = supportedEncoders.getOrNull(client) ?: continue

--- a/protocol/osrs-225/osrs-225-api/src/test/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBufferTest.kt
+++ b/protocol/osrs-225/osrs-225-api/src/test/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBufferTest.kt
@@ -35,6 +35,31 @@ class ZonePartialEnclosedCacheBufferTest {
     }
 
     @Test
+    fun `computeZoneForClient generates a single buffer for the specified client`() {
+        val cache = ZonePartialEnclosedCacheBuffer()
+        val zoneProt = createFullZoneProtList()
+        val client = OldSchoolClientType.DESKTOP
+
+        val buffer = cache.computeZoneForClient(client, zoneProt)
+
+        // Each zone prot should _at minimum_ write their `indexedEncoder` id. (written as a byte)
+        // Ensuring every zone prot opcode/payload is written correctly falls out of scope for this test.
+        val expectedMinReadableBytes = zoneProt.size * Byte.SIZE_BYTES
+        assertTrue(
+            buffer.readableBytes() >= expectedMinReadableBytes,
+            "Expected `$expectedMinReadableBytes` readable bytes from buffer for client: $client. " +
+                "(bytes=${buffer.readableBytes()})",
+        )
+
+        assertEquals(
+            1,
+            cache.currentZoneComputationCount,
+            "Zone computation should increment by 1 for a single client's buffer.",
+        )
+        assertEquals(1, cache.activeCachedBuffers.size)
+    }
+
+    @Test
     fun `releaseBuffers resets computation count and releases buffers correctly`() {
         val cache = ZonePartialEnclosedCacheBuffer(listOf(OldSchoolClientType.DESKTOP))
 

--- a/protocol/osrs-225/osrs-225-api/src/test/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBufferTest.kt
+++ b/protocol/osrs-225/osrs-225-api/src/test/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBufferTest.kt
@@ -22,45 +22,16 @@ import kotlin.test.Test
 
 class ZonePartialEnclosedCacheBufferTest {
     @Test
-    fun `every available oldschool client type has an associated encoder`() {
-        val encoders = ZonePartialEnclosedCacheBuffer.createEncoderMap()
-        assertEquals(OldSchoolClientType.entries.toSet(), encoders.toClientList().toSet())
-    }
-
-    @Test
     fun `computeZone creates buffers for supported clients`() {
         val cache = ZonePartialEnclosedCacheBuffer()
+        val encoders = ZonePartialEnclosedCacheBuffer.createEncoderMap()
         val buffers = cache.computeZone(emptyList())
 
-        assertEquals(buffers.keys.toSet(), cache.supportedClients.toSet())
+        assertEquals(encoders.toClientList().toSet(), buffers.keys.toSet())
 
         // `computeZone` did not receive any zone prot to encode, so all buffers should be empty.
         val expectedBuffers = buffers.map { Unpooled.wrappedBuffer(ByteArray(0)) }
         assertEquals(expectedBuffers, buffers.values.toList())
-    }
-
-    @Test
-    fun `compute zone partial enclosed buffers`() {
-        val cache = ZonePartialEnclosedCacheBuffer()
-
-        val zoneProt = createFullZoneProtList()
-        val buffers = cache.computeZone(zoneProt)
-
-        // Each zone prot should _at minimum_ write their `indexedEncoder` id. (written as a byte)
-        // Ensuring every zone prot opcode/payload is written correctly falls out of scope for this test.
-        val expectedMinReadableBytes = zoneProt.size * Byte.SIZE_BYTES
-        for ((client, buffer) in buffers) {
-            assertTrue(buffer.readableBytes() >= expectedMinReadableBytes) {
-                "Expected `$expectedMinReadableBytes` readable bytes from " +
-                    "buffer for client: $client. (bytes=${buffer.readableBytes()})"
-            }
-        }
-
-        // Each supported client type should have added a buffer to `activeCachedBuffers`.
-        assertEquals(cache.supportedClients.size, buffers.size)
-
-        // The leak-reference-counter should have been incremented by a single zone.
-        assertEquals(1, cache.currentZoneComputationCount)
     }
 
     @Test

--- a/protocol/osrs-225/osrs-225-common/src/main/kotlin/net/rsprot/protocol/common/client/OldSchoolClientType.kt
+++ b/protocol/osrs-225/osrs-225-common/src/main/kotlin/net/rsprot/protocol/common/client/OldSchoolClientType.kt
@@ -11,6 +11,18 @@ public enum class OldSchoolClientType(
      * we use the same client type for both here.
      */
     DESKTOP(0),
+
+    /**
+     * The Android client.
+     * This is a separate client type as the protocol differs from the desktop clients.
+     */
+    ANDROID(1),
+
+    /**
+     * The iOS client.
+     * This is a separate client type as the protocol differs from the desktop clients.
+     */
+    IOS(2),
     ;
 
     public companion object {
@@ -20,6 +32,6 @@ public enum class OldSchoolClientType(
          * as our buffers are often cached per-client type, and we need to use
          * client types as the array index.
          */
-        public const val COUNT: Int = 1
+        public const val COUNT: Int = 3
     }
 }

--- a/protocol/osrs-225/osrs-225-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/header/DesktopUpdateZonePartialEnclosedEncoder.kt
+++ b/protocol/osrs-225/osrs-225-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/header/DesktopUpdateZonePartialEnclosedEncoder.kt
@@ -63,7 +63,7 @@ public class DesktopUpdateZonePartialEnclosedEncoder : MessageEncoder<UpdateZone
          */
         override fun <T : ZoneProt> buildCache(
             allocator: ByteBufAllocator,
-            messages: List<T>,
+            messages: Collection<T>,
         ): ByteBuf {
             val buffer =
                 allocator

--- a/protocol/osrs-226/osrs-226-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-226/osrs-226-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -184,6 +184,8 @@ public class GameLoginResponseHandler<R>(
                 LoginClientType.ENHANCED_WINDOWS -> OldSchoolClientType.DESKTOP
                 LoginClientType.ENHANCED_LINUX -> OldSchoolClientType.DESKTOP
                 LoginClientType.ENHANCED_MAC -> OldSchoolClientType.DESKTOP
+                LoginClientType.ENHANCED_ANDROID -> OldSchoolClientType.ANDROID
+                LoginClientType.ENHANCED_IOS -> OldSchoolClientType.IOS
                 else -> null
             }
         return oldSchoolClientType

--- a/protocol/osrs-226/osrs-226-api/src/main/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBuffer.kt
+++ b/protocol/osrs-226/osrs-226-api/src/main/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBuffer.kt
@@ -64,7 +64,7 @@ public class ZonePartialEnclosedCacheBuffer
         private fun <T : ZoneProt> buildZoneProtBuffers(protList: List<T>): EnumMap<OldSchoolClientType, ByteBuf> {
             val map = createClientBufferEnumMap()
             for (client in supportedClients) {
-                val encoder = supportedEncoders[client]
+                val encoder = supportedEncoders.getOrNull(client) ?: continue
                 val buffer = encoder.buildCache(byteBufAllocator, protList)
                 map[client] = buffer
             }

--- a/protocol/osrs-226/osrs-226-api/src/main/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBuffer.kt
+++ b/protocol/osrs-226/osrs-226-api/src/main/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBuffer.kt
@@ -61,6 +61,25 @@ public class ZonePartialEnclosedCacheBuffer
             return clientBuffers
         }
 
+        /**
+         * Computes the expected zone payload **only** for a single [OldSchoolClientType] and returns the corresponding
+         * [ByteBuf].
+         *
+         * Similar to [computeZone], but for a single client rather than all [supportedClients].
+         */
+        public fun <T : ZoneProt> computeZoneForClient(
+            client: OldSchoolClientType,
+            pendingTickProtList: List<T>,
+        ): ByteBuf {
+            val encoder = supportedEncoders[client]
+
+            val buffer = encoder.buildCache(byteBufAllocator, pendingTickProtList)
+            activeCachedBuffers.add(buffer)
+            incrementZoneComputationCount()
+
+            return buffer
+        }
+
         private fun <T : ZoneProt> buildZoneProtBuffers(protList: List<T>): EnumMap<OldSchoolClientType, ByteBuf> {
             val map = createClientBufferEnumMap()
             for (client in supportedClients) {

--- a/protocol/osrs-226/osrs-226-api/src/main/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBuffer.kt
+++ b/protocol/osrs-226/osrs-226-api/src/main/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBuffer.kt
@@ -54,7 +54,9 @@ public class ZonePartialEnclosedCacheBuffer
          * - [net.rsprot.protocol.game.outgoing.zone.payload.ObjEnabledOps]
          * - [net.rsprot.protocol.game.outgoing.zone.payload.SoundArea]
          */
-        public fun <T : ZoneProt> computeZone(pendingTickProtList: List<T>): EnumMap<OldSchoolClientType, ByteBuf> {
+        public fun <T : ZoneProt> computeZone(
+            pendingTickProtList: Collection<T>,
+        ): EnumMap<OldSchoolClientType, ByteBuf> {
             val clientBuffers = buildZoneProtBuffers(pendingTickProtList)
             activeCachedBuffers += clientBuffers.values
             incrementZoneComputationCount()
@@ -80,7 +82,9 @@ public class ZonePartialEnclosedCacheBuffer
             return buffer
         }
 
-        private fun <T : ZoneProt> buildZoneProtBuffers(protList: List<T>): EnumMap<OldSchoolClientType, ByteBuf> {
+        private fun <T : ZoneProt> buildZoneProtBuffers(
+            protList: Collection<T>,
+        ): EnumMap<OldSchoolClientType, ByteBuf> {
             val map = createClientBufferEnumMap()
             for (client in supportedClients) {
                 val encoder = supportedEncoders.getOrNull(client) ?: continue

--- a/protocol/osrs-226/osrs-226-api/src/test/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBufferTest.kt
+++ b/protocol/osrs-226/osrs-226-api/src/test/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBufferTest.kt
@@ -22,17 +22,12 @@ import kotlin.test.Test
 
 class ZonePartialEnclosedCacheBufferTest {
     @Test
-    fun `every available oldschool client type has an associated encoder`() {
-        val encoders = ZonePartialEnclosedCacheBuffer.createEncoderMap()
-        assertEquals(OldSchoolClientType.entries.toSet(), encoders.toClientList().toSet())
-    }
-
-    @Test
     fun `computeZone creates buffers for supported clients`() {
         val cache = ZonePartialEnclosedCacheBuffer()
+        val encoders = ZonePartialEnclosedCacheBuffer.createEncoderMap()
         val buffers = cache.computeZone(emptyList())
 
-        assertEquals(buffers.keys.toSet(), cache.supportedClients.toSet())
+        assertEquals(encoders.toClientList().toSet(), buffers.keys.toSet())
 
         // `computeZone` did not receive any zone prot to encode, so all buffers should be empty.
         val expectedBuffers = buffers.map { Unpooled.wrappedBuffer(ByteArray(0)) }
@@ -43,6 +38,7 @@ class ZonePartialEnclosedCacheBufferTest {
     fun `compute zone partial enclosed buffers`() {
         val cache = ZonePartialEnclosedCacheBuffer()
 
+        val encoders = ZonePartialEnclosedCacheBuffer.createEncoderMap()
         val zoneProt = createFullZoneProtList()
         val buffers = cache.computeZone(zoneProt)
 
@@ -57,7 +53,7 @@ class ZonePartialEnclosedCacheBufferTest {
         }
 
         // Each supported client type should have added a buffer to `activeCachedBuffers`.
-        assertEquals(cache.supportedClients.size, buffers.size)
+        assertEquals(encoders.toClientList().size, buffers.size)
 
         // The leak-reference-counter should have been incremented by a single zone.
         assertEquals(1, cache.currentZoneComputationCount)

--- a/protocol/osrs-226/osrs-226-api/src/test/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBufferTest.kt
+++ b/protocol/osrs-226/osrs-226-api/src/test/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBufferTest.kt
@@ -35,6 +35,31 @@ class ZonePartialEnclosedCacheBufferTest {
     }
 
     @Test
+    fun `computeZoneForClient generates a single buffer for the specified client`() {
+        val cache = ZonePartialEnclosedCacheBuffer()
+        val zoneProt = createFullZoneProtList()
+        val client = OldSchoolClientType.DESKTOP
+
+        val buffer = cache.computeZoneForClient(client, zoneProt)
+
+        // Each zone prot should _at minimum_ write their `indexedEncoder` id. (written as a byte)
+        // Ensuring every zone prot opcode/payload is written correctly falls out of scope for this test.
+        val expectedMinReadableBytes = zoneProt.size * Byte.SIZE_BYTES
+        assertTrue(
+            buffer.readableBytes() >= expectedMinReadableBytes,
+            "Expected `$expectedMinReadableBytes` readable bytes from buffer for client: $client. " +
+                "(bytes=${buffer.readableBytes()})",
+        )
+
+        assertEquals(
+            1,
+            cache.currentZoneComputationCount,
+            "Zone computation should increment by 1 for a single client's buffer.",
+        )
+        assertEquals(1, cache.activeCachedBuffers.size)
+    }
+
+    @Test
     fun `compute zone partial enclosed buffers`() {
         val cache = ZonePartialEnclosedCacheBuffer()
 

--- a/protocol/osrs-226/osrs-226-common/src/main/kotlin/net/rsprot/protocol/common/client/OldSchoolClientType.kt
+++ b/protocol/osrs-226/osrs-226-common/src/main/kotlin/net/rsprot/protocol/common/client/OldSchoolClientType.kt
@@ -11,6 +11,18 @@ public enum class OldSchoolClientType(
      * we use the same client type for both here.
      */
     DESKTOP(0),
+
+    /**
+     * The Android client.
+     * This is a separate client type as the protocol differs from the desktop clients.
+     */
+    ANDROID(1),
+
+    /**
+     * The iOS client.
+     * This is a separate client type as the protocol differs from the desktop clients.
+     */
+    IOS(2),
     ;
 
     public companion object {
@@ -20,6 +32,6 @@ public enum class OldSchoolClientType(
          * as our buffers are often cached per-client type, and we need to use
          * client types as the array index.
          */
-        public const val COUNT: Int = 1
+        public const val COUNT: Int = 3
     }
 }

--- a/protocol/osrs-226/osrs-226-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/header/DesktopUpdateZonePartialEnclosedEncoder.kt
+++ b/protocol/osrs-226/osrs-226-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/header/DesktopUpdateZonePartialEnclosedEncoder.kt
@@ -66,7 +66,7 @@ public class DesktopUpdateZonePartialEnclosedEncoder : MessageEncoder<UpdateZone
          */
         override fun <T : ZoneProt> buildCache(
             allocator: ByteBufAllocator,
-            messages: List<T>,
+            messages: Collection<T>,
         ): ByteBuf {
             val buffer =
                 allocator

--- a/protocol/osrs-227/osrs-227-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-227/osrs-227-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -184,6 +184,8 @@ public class GameLoginResponseHandler<R>(
                 LoginClientType.ENHANCED_WINDOWS -> OldSchoolClientType.DESKTOP
                 LoginClientType.ENHANCED_LINUX -> OldSchoolClientType.DESKTOP
                 LoginClientType.ENHANCED_MAC -> OldSchoolClientType.DESKTOP
+                LoginClientType.ENHANCED_ANDROID -> OldSchoolClientType.ANDROID
+                LoginClientType.ENHANCED_IOS -> OldSchoolClientType.IOS
                 else -> null
             }
         return oldSchoolClientType

--- a/protocol/osrs-227/osrs-227-api/src/main/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBuffer.kt
+++ b/protocol/osrs-227/osrs-227-api/src/main/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBuffer.kt
@@ -64,7 +64,7 @@ public class ZonePartialEnclosedCacheBuffer
         private fun <T : ZoneProt> buildZoneProtBuffers(protList: List<T>): EnumMap<OldSchoolClientType, ByteBuf> {
             val map = createClientBufferEnumMap()
             for (client in supportedClients) {
-                val encoder = supportedEncoders[client]
+                val encoder = supportedEncoders.getOrNull(client) ?: continue
                 val buffer = encoder.buildCache(byteBufAllocator, protList)
                 map[client] = buffer
             }

--- a/protocol/osrs-227/osrs-227-api/src/main/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBuffer.kt
+++ b/protocol/osrs-227/osrs-227-api/src/main/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBuffer.kt
@@ -61,6 +61,25 @@ public class ZonePartialEnclosedCacheBuffer
             return clientBuffers
         }
 
+        /**
+         * Computes the expected zone payload **only** for a single [OldSchoolClientType] and returns the corresponding
+         * [ByteBuf].
+         *
+         * Similar to [computeZone], but for a single client rather than all [supportedClients].
+         */
+        public fun <T : ZoneProt> computeZoneForClient(
+            client: OldSchoolClientType,
+            pendingTickProtList: List<T>,
+        ): ByteBuf {
+            val encoder = supportedEncoders[client]
+
+            val buffer = encoder.buildCache(byteBufAllocator, pendingTickProtList)
+            activeCachedBuffers.add(buffer)
+            incrementZoneComputationCount()
+
+            return buffer
+        }
+
         private fun <T : ZoneProt> buildZoneProtBuffers(protList: List<T>): EnumMap<OldSchoolClientType, ByteBuf> {
             val map = createClientBufferEnumMap()
             for (client in supportedClients) {

--- a/protocol/osrs-227/osrs-227-api/src/main/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBuffer.kt
+++ b/protocol/osrs-227/osrs-227-api/src/main/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBuffer.kt
@@ -54,7 +54,9 @@ public class ZonePartialEnclosedCacheBuffer
          * - [net.rsprot.protocol.game.outgoing.zone.payload.ObjEnabledOps]
          * - [net.rsprot.protocol.game.outgoing.zone.payload.SoundArea]
          */
-        public fun <T : ZoneProt> computeZone(pendingTickProtList: List<T>): EnumMap<OldSchoolClientType, ByteBuf> {
+        public fun <T : ZoneProt> computeZone(
+            pendingTickProtList: Collection<T>,
+        ): EnumMap<OldSchoolClientType, ByteBuf> {
             val clientBuffers = buildZoneProtBuffers(pendingTickProtList)
             activeCachedBuffers += clientBuffers.values
             incrementZoneComputationCount()
@@ -69,7 +71,7 @@ public class ZonePartialEnclosedCacheBuffer
          */
         public fun <T : ZoneProt> computeZoneForClient(
             client: OldSchoolClientType,
-            pendingTickProtList: List<T>,
+            pendingTickProtList: Collection<T>,
         ): ByteBuf {
             val encoder = supportedEncoders[client]
 
@@ -80,7 +82,9 @@ public class ZonePartialEnclosedCacheBuffer
             return buffer
         }
 
-        private fun <T : ZoneProt> buildZoneProtBuffers(protList: List<T>): EnumMap<OldSchoolClientType, ByteBuf> {
+        private fun <T : ZoneProt> buildZoneProtBuffers(
+            protList: Collection<T>,
+        ): EnumMap<OldSchoolClientType, ByteBuf> {
             val map = createClientBufferEnumMap()
             for (client in supportedClients) {
                 val encoder = supportedEncoders.getOrNull(client) ?: continue

--- a/protocol/osrs-227/osrs-227-api/src/test/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBufferTest.kt
+++ b/protocol/osrs-227/osrs-227-api/src/test/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBufferTest.kt
@@ -22,17 +22,12 @@ import kotlin.test.Test
 
 class ZonePartialEnclosedCacheBufferTest {
     @Test
-    fun `every available oldschool client type has an associated encoder`() {
-        val encoders = ZonePartialEnclosedCacheBuffer.createEncoderMap()
-        assertEquals(OldSchoolClientType.entries.toSet(), encoders.toClientList().toSet())
-    }
-
-    @Test
     fun `computeZone creates buffers for supported clients`() {
         val cache = ZonePartialEnclosedCacheBuffer()
+        val encoders = ZonePartialEnclosedCacheBuffer.createEncoderMap()
         val buffers = cache.computeZone(emptyList())
 
-        assertEquals(buffers.keys.toSet(), cache.supportedClients.toSet())
+        assertEquals(encoders.toClientList().toSet(), buffers.keys.toSet())
 
         // `computeZone` did not receive any zone prot to encode, so all buffers should be empty.
         val expectedBuffers = buffers.map { Unpooled.wrappedBuffer(ByteArray(0)) }
@@ -43,6 +38,7 @@ class ZonePartialEnclosedCacheBufferTest {
     fun `compute zone partial enclosed buffers`() {
         val cache = ZonePartialEnclosedCacheBuffer()
 
+        val encoders = ZonePartialEnclosedCacheBuffer.createEncoderMap()
         val zoneProt = createFullZoneProtList()
         val buffers = cache.computeZone(zoneProt)
 
@@ -57,7 +53,7 @@ class ZonePartialEnclosedCacheBufferTest {
         }
 
         // Each supported client type should have added a buffer to `activeCachedBuffers`.
-        assertEquals(cache.supportedClients.size, buffers.size)
+        assertEquals(encoders.toClientList().size, buffers.size)
 
         // The leak-reference-counter should have been incremented by a single zone.
         assertEquals(1, cache.currentZoneComputationCount)

--- a/protocol/osrs-227/osrs-227-api/src/test/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBufferTest.kt
+++ b/protocol/osrs-227/osrs-227-api/src/test/kotlin/net/rsprot/protocol/api/util/ZonePartialEnclosedCacheBufferTest.kt
@@ -35,6 +35,31 @@ class ZonePartialEnclosedCacheBufferTest {
     }
 
     @Test
+    fun `computeZoneForClient generates a single buffer for the specified client`() {
+        val cache = ZonePartialEnclosedCacheBuffer()
+        val zoneProt = createFullZoneProtList()
+        val client = OldSchoolClientType.DESKTOP
+
+        val buffer = cache.computeZoneForClient(client, zoneProt)
+
+        // Each zone prot should _at minimum_ write their `indexedEncoder` id. (written as a byte)
+        // Ensuring every zone prot opcode/payload is written correctly falls out of scope for this test.
+        val expectedMinReadableBytes = zoneProt.size * Byte.SIZE_BYTES
+        assertTrue(
+            buffer.readableBytes() >= expectedMinReadableBytes,
+            "Expected `$expectedMinReadableBytes` readable bytes from buffer for client: $client. " +
+                "(bytes=${buffer.readableBytes()})",
+        )
+
+        assertEquals(
+            1,
+            cache.currentZoneComputationCount,
+            "Zone computation should increment by 1 for a single client's buffer.",
+        )
+        assertEquals(1, cache.activeCachedBuffers.size)
+    }
+
+    @Test
     fun `compute zone partial enclosed buffers`() {
         val cache = ZonePartialEnclosedCacheBuffer()
 

--- a/protocol/osrs-227/osrs-227-common/src/main/kotlin/net/rsprot/protocol/common/client/OldSchoolClientType.kt
+++ b/protocol/osrs-227/osrs-227-common/src/main/kotlin/net/rsprot/protocol/common/client/OldSchoolClientType.kt
@@ -11,6 +11,18 @@ public enum class OldSchoolClientType(
      * we use the same client type for both here.
      */
     DESKTOP(0),
+
+    /**
+     * The Android client.
+     * This is a separate client type as the protocol differs from the desktop clients.
+     */
+    ANDROID(1),
+
+    /**
+     * The iOS client.
+     * This is a separate client type as the protocol differs from the desktop clients.
+     */
+    IOS(2),
     ;
 
     public companion object {
@@ -20,6 +32,6 @@ public enum class OldSchoolClientType(
          * as our buffers are often cached per-client type, and we need to use
          * client types as the array index.
          */
-        public const val COUNT: Int = 1
+        public const val COUNT: Int = 3
     }
 }

--- a/protocol/osrs-227/osrs-227-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/header/DesktopUpdateZonePartialEnclosedEncoder.kt
+++ b/protocol/osrs-227/osrs-227-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/zone/header/DesktopUpdateZonePartialEnclosedEncoder.kt
@@ -66,7 +66,7 @@ public class DesktopUpdateZonePartialEnclosedEncoder : MessageEncoder<UpdateZone
          */
         override fun <T : ZoneProt> buildCache(
             allocator: ByteBufAllocator,
-            messages: List<T>,
+            messages: Collection<T>,
         ): ByteBuf {
             val buffer =
                 allocator

--- a/protocol/src/main/kotlin/net/rsprot/protocol/message/codec/UpdateZonePartialEnclosedCache.kt
+++ b/protocol/src/main/kotlin/net/rsprot/protocol/message/codec/UpdateZonePartialEnclosedCache.kt
@@ -7,6 +7,6 @@ import net.rsprot.protocol.message.ZoneProt
 public interface UpdateZonePartialEnclosedCache {
     public fun <T : ZoneProt> buildCache(
         allocator: ByteBufAllocator,
-        messages: List<T>,
+        messages: Collection<T>,
     ): ByteBuf
 }


### PR DESCRIPTION
Prior to this PR, there was only a way to generate a map of `ZonePartialEnclosedCacheBuffer`.

Now we can pick a single `ClientType` to generate.
Additionally adds in both mobile `ClientType` definitions