### PR TITLE
Login response handler validation rework

### DIFF
--- a/protocol/osrs-221/osrs-221-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-221/osrs-221-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -49,12 +49,6 @@ public class GameLoginResponseHandler<R>(
             checkNotNull(loginBlock.clientType.toOldSchoolClientType()) {
                 "Login client type cannot be null"
             }
-        if (!ctx.channel().isActive) {
-            networkLog(logger) {
-                "Channel '${ctx.channel()}' has gone inactive; login block: $loginBlock"
-            }
-            return null
-        }
         val address = ctx.inetAddress()
         val count =
             networkService
@@ -105,19 +99,13 @@ public class GameLoginResponseHandler<R>(
     public fun writeSuccessfulResponse(
         response: LoginResponse.ReconnectOk,
         loginBlock: LoginBlock<*>,
-    ): Session<R>? {
+    ): Session<R> {
         // Ensure it isn't null - our decoder pre-validates it long before hitting this function,
         // so this exception should never be hit.
         val oldSchoolClientType =
             checkNotNull(loginBlock.clientType.toOldSchoolClientType()) {
                 "Login client type cannot be null"
             }
-        if (!ctx.channel().isActive) {
-            networkLog(logger) {
-                "Channel '${ctx.channel()}' has gone inactive; login block: $loginBlock"
-            }
-            return null
-        }
         val (encodingCipher, decodingCipher) = createStreamCipherPair(loginBlock)
 
         // Unlike in the above case, we kind of have to assume it was successful

--- a/protocol/osrs-221/osrs-221-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-221/osrs-221-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -20,7 +20,6 @@ import net.rsprot.protocol.api.game.GameMessageHandler
 import net.rsprot.protocol.api.logging.networkLog
 import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.loginprot.incoming.util.LoginBlock
-import net.rsprot.protocol.loginprot.incoming.util.LoginClientType
 import net.rsprot.protocol.loginprot.outgoing.LoginResponse
 import java.util.concurrent.TimeUnit
 
@@ -44,18 +43,12 @@ public class GameLoginResponseHandler<R>(
         response: LoginResponse.Ok,
         loginBlock: LoginBlock<*>,
     ): Session<R>? {
+        // Ensure it isn't null - our decoder pre-validates it long before hitting this function,
+        // so this exception should never be hit.
         val oldSchoolClientType =
-            getOldSchoolClientType(loginBlock)
-        if (oldSchoolClientType == null || !networkService.isSupported(oldSchoolClientType)) {
-            networkLog(logger) {
-                "Unsupported client type received from channel " +
-                    "'${ctx.channel()}': $oldSchoolClientType, login block: $loginBlock"
+            checkNotNull(loginBlock.clientType.toOldSchoolClientType()) {
+                "Login client type cannot be null"
             }
-            ctx
-                .writeAndFlush(LoginResponse.InvalidLoginPacket)
-                .addListener(ChannelFutureListener.CLOSE)
-            return null
-        }
         if (!ctx.channel().isActive) {
             networkLog(logger) {
                 "Channel '${ctx.channel()}' has gone inactive; login block: $loginBlock"
@@ -113,16 +106,12 @@ public class GameLoginResponseHandler<R>(
         response: LoginResponse.ReconnectOk,
         loginBlock: LoginBlock<*>,
     ): Session<R>? {
+        // Ensure it isn't null - our decoder pre-validates it long before hitting this function,
+        // so this exception should never be hit.
         val oldSchoolClientType =
-            getOldSchoolClientType(loginBlock)
-        if (oldSchoolClientType == null || !networkService.isSupported(oldSchoolClientType)) {
-            networkLog(logger) {
-                "Unsupported client type received from channel " +
-                    "'${ctx.channel()}': $oldSchoolClientType, login block: $loginBlock"
+            checkNotNull(loginBlock.clientType.toOldSchoolClientType()) {
+                "Login client type cannot be null"
             }
-            ctx.writeAndFlush(LoginResponse.InvalidLoginPacket)
-            return null
-        }
         if (!ctx.channel().isActive) {
             networkLog(logger) {
                 "Channel '${ctx.channel()}' has gone inactive; login block: $loginBlock"
@@ -155,20 +144,6 @@ public class GameLoginResponseHandler<R>(
         val encodingCipher = provider.provide(decodeSeed)
         val decodingCipher = provider.provide(encodeSeed)
         return StreamCipherPair(encodingCipher, decodingCipher)
-    }
-
-    private fun getOldSchoolClientType(loginBlock: LoginBlock<*>): OldSchoolClientType? {
-        val oldSchoolClientType =
-            when (loginBlock.clientType) {
-                LoginClientType.DESKTOP -> OldSchoolClientType.DESKTOP
-                LoginClientType.ENHANCED_WINDOWS -> OldSchoolClientType.DESKTOP
-                LoginClientType.ENHANCED_LINUX -> OldSchoolClientType.DESKTOP
-                LoginClientType.ENHANCED_MAC -> OldSchoolClientType.DESKTOP
-                LoginClientType.ENHANCED_ANDROID -> OldSchoolClientType.ANDROID
-                LoginClientType.ENHANCED_IOS -> OldSchoolClientType.IOS
-                else -> null
-            }
-        return oldSchoolClientType
     }
 
     private fun createSession(

--- a/protocol/osrs-221/osrs-221-api/src/main/kotlin/net/rsprot/protocol/api/repositories/MessageDecoderRepositories.kt
+++ b/protocol/osrs-221/osrs-221-api/src/main/kotlin/net/rsprot/protocol/api/repositories/MessageDecoderRepositories.kt
@@ -22,11 +22,12 @@ public class MessageDecoderRepositories private constructor(
     public val gameMessageDecoderRepositories: ClientTypeMap<MessageDecoderRepository<ClientProt>>,
 ) {
     public constructor(
+        clientTypes: List<OldSchoolClientType>,
         exp: BigInteger,
         mod: BigInteger,
         gameMessageDecoderRepositories: ClientTypeMap<MessageDecoderRepository<ClientProt>>,
     ) : this(
-        LoginMessageDecoderRepository.build(exp, mod),
+        LoginMessageDecoderRepository.build(clientTypes, exp, mod),
         Js5MessageDecoderRepository.build(),
         gameMessageDecoderRepositories,
     )
@@ -49,6 +50,7 @@ public class MessageDecoderRepositories private constructor(
                     repositories,
                 )
             return MessageDecoderRepositories(
+                clientTypes,
                 rsaKeyPair.exponent,
                 rsaKeyPair.modulus,
                 clientTypeMap,

--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/LoginClientType.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/LoginClientType.kt
@@ -1,5 +1,7 @@
 package net.rsprot.protocol.loginprot.incoming.util
 
+import net.rsprot.protocol.common.client.OldSchoolClientType
+
 public enum class LoginClientType(
     public val id: Int,
 ) {
@@ -12,6 +14,18 @@ public enum class LoginClientType(
     ENHANCED_IOS(8),
     ENHANCED_LINUX(10),
     ;
+
+    public fun toOldSchoolClientType(): OldSchoolClientType? {
+        return when (this) {
+            DESKTOP -> OldSchoolClientType.DESKTOP
+            ENHANCED_WINDOWS -> OldSchoolClientType.DESKTOP
+            ENHANCED_LINUX -> OldSchoolClientType.DESKTOP
+            ENHANCED_MAC -> OldSchoolClientType.DESKTOP
+            ENHANCED_ANDROID -> OldSchoolClientType.ANDROID
+            ENHANCED_IOS -> OldSchoolClientType.IOS
+            else -> null
+        }
+    }
 
     public companion object {
         public operator fun get(id: Int): LoginClientType =

--- a/protocol/osrs-221/osrs-221-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameLoginDecoder.kt
+++ b/protocol/osrs-221/osrs-221-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameLoginDecoder.kt
@@ -3,6 +3,7 @@ package net.rsprot.protocol.common.loginprot.incoming.codec
 import net.rsprot.buffer.JagByteBuf
 import net.rsprot.buffer.extensions.toJagByteBuf
 import net.rsprot.protocol.ClientProt
+import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.common.loginprot.incoming.codec.shared.LoginBlockDecoder
 import net.rsprot.protocol.common.loginprot.incoming.prot.LoginClientProt
 import net.rsprot.protocol.loginprot.incoming.GameLogin
@@ -14,6 +15,7 @@ import net.rsprot.protocol.message.codec.MessageDecoder
 import java.math.BigInteger
 
 public class GameLoginDecoder(
+    private val supportedClientTypes: List<OldSchoolClientType>,
     exp: BigInteger,
     mod: BigInteger,
 ) : LoginBlockDecoder<AuthenticationType<*>>(exp, mod),
@@ -25,7 +27,7 @@ public class GameLoginDecoder(
         // Mark the buffer as "read" as copy function doesn't do it automatically.
         buffer.buffer.readerIndex(buffer.buffer.writerIndex())
         return GameLogin(copy.toJagByteBuf()) { jagByteBuf, betaWorld ->
-            decodeLoginBlock(jagByteBuf, betaWorld)
+            decodeLoginBlock(jagByteBuf, betaWorld, supportedClientTypes)
         }
     }
 

--- a/protocol/osrs-221/osrs-221-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameReconnectDecoder.kt
+++ b/protocol/osrs-221/osrs-221-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameReconnectDecoder.kt
@@ -4,6 +4,7 @@ import net.rsprot.buffer.JagByteBuf
 import net.rsprot.buffer.extensions.toJagByteBuf
 import net.rsprot.crypto.xtea.XteaKey
 import net.rsprot.protocol.ClientProt
+import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.common.loginprot.incoming.codec.shared.LoginBlockDecoder
 import net.rsprot.protocol.common.loginprot.incoming.prot.LoginClientProt
 import net.rsprot.protocol.loginprot.incoming.GameReconnect
@@ -11,6 +12,7 @@ import net.rsprot.protocol.message.codec.MessageDecoder
 import java.math.BigInteger
 
 public class GameReconnectDecoder(
+    private val supportedClientTypes: List<OldSchoolClientType>,
     exp: BigInteger,
     mod: BigInteger,
 ) : LoginBlockDecoder<XteaKey>(exp, mod),
@@ -22,7 +24,7 @@ public class GameReconnectDecoder(
         // Mark the buffer as "read" as copy function doesn't do it automatically.
         buffer.buffer.readerIndex(buffer.buffer.writerIndex())
         return GameReconnect(copy.toJagByteBuf()) { jagByteBuf, betaWorld ->
-            decodeLoginBlock(jagByteBuf, betaWorld)
+            decodeLoginBlock(jagByteBuf, betaWorld, supportedClientTypes)
         }
     }
 

--- a/protocol/osrs-221/osrs-221-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/shared/exceptions/UnsupportedClientException.kt
+++ b/protocol/osrs-221/osrs-221-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/shared/exceptions/UnsupportedClientException.kt
@@ -1,0 +1,12 @@
+package net.rsprot.protocol.common.loginprot.incoming.codec.shared.exceptions
+
+/**
+ * A singleton exception for whenever login decoding fails due to an unsupported client connecting to it.
+ * It is not ideal to be using exceptions for flow control, but it is by far the easiest option
+ * here. From a performance standpoint, only building stack traces is slow, which we aren't
+ * going to be doing for this type of exception.
+ */
+public data object UnsupportedClientException : RuntimeException() {
+    @Suppress("unused")
+    private fun readResolve(): Any = UnsupportedClientException
+}

--- a/protocol/osrs-221/osrs-221-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/prot/LoginMessageDecoderRepository.kt
+++ b/protocol/osrs-221/osrs-221-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/prot/LoginMessageDecoderRepository.kt
@@ -1,6 +1,7 @@
 package net.rsprot.protocol.common.loginprot.incoming.prot
 
 import net.rsprot.protocol.ProtRepository
+import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.common.loginprot.incoming.codec.GameLoginDecoder
 import net.rsprot.protocol.common.loginprot.incoming.codec.GameReconnectDecoder
 import net.rsprot.protocol.common.loginprot.incoming.codec.InitGameConnectionDecoder
@@ -14,6 +15,7 @@ import java.math.BigInteger
 public object LoginMessageDecoderRepository {
     @ExperimentalStdlibApi
     public fun build(
+        supportedClientTypes: List<OldSchoolClientType>,
         exp: BigInteger,
         mod: BigInteger,
     ): MessageDecoderRepository<LoginClientProt> {
@@ -24,8 +26,8 @@ public object LoginMessageDecoderRepository {
             ).apply {
                 bind(InitGameConnectionDecoder())
                 bind(InitJs5RemoteConnectionDecoder())
-                bind(GameLoginDecoder(exp, mod))
-                bind(GameReconnectDecoder(exp, mod))
+                bind(GameLoginDecoder(supportedClientTypes, exp, mod))
+                bind(GameReconnectDecoder(supportedClientTypes, exp, mod))
                 bind(ProofOfWorkReplyDecoder())
                 bind(RemainingBetaArchivesDecoder())
             }

--- a/protocol/osrs-222/osrs-222-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-222/osrs-222-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -49,12 +49,6 @@ public class GameLoginResponseHandler<R>(
             checkNotNull(loginBlock.clientType.toOldSchoolClientType()) {
                 "Login client type cannot be null"
             }
-        if (!ctx.channel().isActive) {
-            networkLog(logger) {
-                "Channel '${ctx.channel()}' has gone inactive; login block: $loginBlock"
-            }
-            return null
-        }
         val address = ctx.inetAddress()
         val count =
             networkService
@@ -105,19 +99,13 @@ public class GameLoginResponseHandler<R>(
     public fun writeSuccessfulResponse(
         response: LoginResponse.ReconnectOk,
         loginBlock: LoginBlock<*>,
-    ): Session<R>? {
+    ): Session<R> {
         // Ensure it isn't null - our decoder pre-validates it long before hitting this function,
         // so this exception should never be hit.
         val oldSchoolClientType =
             checkNotNull(loginBlock.clientType.toOldSchoolClientType()) {
                 "Login client type cannot be null"
             }
-        if (!ctx.channel().isActive) {
-            networkLog(logger) {
-                "Channel '${ctx.channel()}' has gone inactive; login block: $loginBlock"
-            }
-            return null
-        }
         val (encodingCipher, decodingCipher) = createStreamCipherPair(loginBlock)
 
         // Unlike in the above case, we kind of have to assume it was successful

--- a/protocol/osrs-222/osrs-222-api/src/main/kotlin/net/rsprot/protocol/api/repositories/MessageDecoderRepositories.kt
+++ b/protocol/osrs-222/osrs-222-api/src/main/kotlin/net/rsprot/protocol/api/repositories/MessageDecoderRepositories.kt
@@ -22,11 +22,12 @@ public class MessageDecoderRepositories private constructor(
     public val gameMessageDecoderRepositories: ClientTypeMap<MessageDecoderRepository<ClientProt>>,
 ) {
     public constructor(
+        clientTypes: List<OldSchoolClientType>,
         exp: BigInteger,
         mod: BigInteger,
         gameMessageDecoderRepositories: ClientTypeMap<MessageDecoderRepository<ClientProt>>,
     ) : this(
-        LoginMessageDecoderRepository.build(exp, mod),
+        LoginMessageDecoderRepository.build(clientTypes, exp, mod),
         Js5MessageDecoderRepository.build(),
         gameMessageDecoderRepositories,
     )
@@ -49,6 +50,7 @@ public class MessageDecoderRepositories private constructor(
                     repositories,
                 )
             return MessageDecoderRepositories(
+                clientTypes,
                 rsaKeyPair.exponent,
                 rsaKeyPair.modulus,
                 clientTypeMap,

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/LoginClientType.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/LoginClientType.kt
@@ -1,5 +1,7 @@
 package net.rsprot.protocol.loginprot.incoming.util
 
+import net.rsprot.protocol.common.client.OldSchoolClientType
+
 public enum class LoginClientType(
     public val id: Int,
 ) {
@@ -12,6 +14,18 @@ public enum class LoginClientType(
     ENHANCED_IOS(8),
     ENHANCED_LINUX(10),
     ;
+
+    public fun toOldSchoolClientType(): OldSchoolClientType? {
+        return when (this) {
+            DESKTOP -> OldSchoolClientType.DESKTOP
+            ENHANCED_WINDOWS -> OldSchoolClientType.DESKTOP
+            ENHANCED_LINUX -> OldSchoolClientType.DESKTOP
+            ENHANCED_MAC -> OldSchoolClientType.DESKTOP
+            ENHANCED_ANDROID -> OldSchoolClientType.ANDROID
+            ENHANCED_IOS -> OldSchoolClientType.IOS
+            else -> null
+        }
+    }
 
     public companion object {
         public operator fun get(id: Int): LoginClientType =

--- a/protocol/osrs-222/osrs-222-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameLoginDecoder.kt
+++ b/protocol/osrs-222/osrs-222-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameLoginDecoder.kt
@@ -3,6 +3,7 @@ package net.rsprot.protocol.common.loginprot.incoming.codec
 import net.rsprot.buffer.JagByteBuf
 import net.rsprot.buffer.extensions.toJagByteBuf
 import net.rsprot.protocol.ClientProt
+import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.common.loginprot.incoming.codec.shared.LoginBlockDecoder
 import net.rsprot.protocol.common.loginprot.incoming.prot.LoginClientProt
 import net.rsprot.protocol.loginprot.incoming.GameLogin
@@ -14,6 +15,7 @@ import net.rsprot.protocol.message.codec.MessageDecoder
 import java.math.BigInteger
 
 public class GameLoginDecoder(
+    private val supportedClientTypes: List<OldSchoolClientType>,
     exp: BigInteger,
     mod: BigInteger,
 ) : LoginBlockDecoder<AuthenticationType<*>>(exp, mod),
@@ -25,7 +27,7 @@ public class GameLoginDecoder(
         // Mark the buffer as "read" as copy function doesn't do it automatically.
         buffer.buffer.readerIndex(buffer.buffer.writerIndex())
         return GameLogin(copy.toJagByteBuf()) { jagByteBuf, betaWorld ->
-            decodeLoginBlock(jagByteBuf, betaWorld)
+            decodeLoginBlock(jagByteBuf, betaWorld, supportedClientTypes)
         }
     }
 

--- a/protocol/osrs-222/osrs-222-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameReconnectDecoder.kt
+++ b/protocol/osrs-222/osrs-222-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameReconnectDecoder.kt
@@ -4,6 +4,7 @@ import net.rsprot.buffer.JagByteBuf
 import net.rsprot.buffer.extensions.toJagByteBuf
 import net.rsprot.crypto.xtea.XteaKey
 import net.rsprot.protocol.ClientProt
+import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.common.loginprot.incoming.codec.shared.LoginBlockDecoder
 import net.rsprot.protocol.common.loginprot.incoming.prot.LoginClientProt
 import net.rsprot.protocol.loginprot.incoming.GameReconnect
@@ -11,6 +12,7 @@ import net.rsprot.protocol.message.codec.MessageDecoder
 import java.math.BigInteger
 
 public class GameReconnectDecoder(
+    private val supportedClientTypes: List<OldSchoolClientType>,
     exp: BigInteger,
     mod: BigInteger,
 ) : LoginBlockDecoder<XteaKey>(exp, mod),
@@ -22,7 +24,7 @@ public class GameReconnectDecoder(
         // Mark the buffer as "read" as copy function doesn't do it automatically.
         buffer.buffer.readerIndex(buffer.buffer.writerIndex())
         return GameReconnect(copy.toJagByteBuf()) { jagByteBuf, betaWorld ->
-            decodeLoginBlock(jagByteBuf, betaWorld)
+            decodeLoginBlock(jagByteBuf, betaWorld, supportedClientTypes)
         }
     }
 

--- a/protocol/osrs-222/osrs-222-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/shared/exceptions/UnsupportedClientException.kt
+++ b/protocol/osrs-222/osrs-222-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/shared/exceptions/UnsupportedClientException.kt
@@ -1,0 +1,12 @@
+package net.rsprot.protocol.common.loginprot.incoming.codec.shared.exceptions
+
+/**
+ * A singleton exception for whenever login decoding fails due to an unsupported client connecting to it.
+ * It is not ideal to be using exceptions for flow control, but it is by far the easiest option
+ * here. From a performance standpoint, only building stack traces is slow, which we aren't
+ * going to be doing for this type of exception.
+ */
+public data object UnsupportedClientException : RuntimeException() {
+    @Suppress("unused")
+    private fun readResolve(): Any = UnsupportedClientException
+}

--- a/protocol/osrs-222/osrs-222-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/prot/LoginMessageDecoderRepository.kt
+++ b/protocol/osrs-222/osrs-222-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/prot/LoginMessageDecoderRepository.kt
@@ -1,6 +1,7 @@
 package net.rsprot.protocol.common.loginprot.incoming.prot
 
 import net.rsprot.protocol.ProtRepository
+import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.common.loginprot.incoming.codec.GameLoginDecoder
 import net.rsprot.protocol.common.loginprot.incoming.codec.GameReconnectDecoder
 import net.rsprot.protocol.common.loginprot.incoming.codec.InitGameConnectionDecoder
@@ -14,6 +15,7 @@ import java.math.BigInteger
 public object LoginMessageDecoderRepository {
     @ExperimentalStdlibApi
     public fun build(
+        supportedClientTypes: List<OldSchoolClientType>,
         exp: BigInteger,
         mod: BigInteger,
     ): MessageDecoderRepository<LoginClientProt> {
@@ -24,8 +26,8 @@ public object LoginMessageDecoderRepository {
             ).apply {
                 bind(InitGameConnectionDecoder())
                 bind(InitJs5RemoteConnectionDecoder())
-                bind(GameLoginDecoder(exp, mod))
-                bind(GameReconnectDecoder(exp, mod))
+                bind(GameLoginDecoder(supportedClientTypes, exp, mod))
+                bind(GameReconnectDecoder(supportedClientTypes, exp, mod))
                 bind(ProofOfWorkReplyDecoder())
                 bind(RemainingBetaArchivesDecoder())
             }

--- a/protocol/osrs-223/osrs-223-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-223/osrs-223-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -49,12 +49,6 @@ public class GameLoginResponseHandler<R>(
             checkNotNull(loginBlock.clientType.toOldSchoolClientType()) {
                 "Login client type cannot be null"
             }
-        if (!ctx.channel().isActive) {
-            networkLog(logger) {
-                "Channel '${ctx.channel()}' has gone inactive; login block: $loginBlock"
-            }
-            return null
-        }
         val address = ctx.inetAddress()
         val count =
             networkService
@@ -105,19 +99,13 @@ public class GameLoginResponseHandler<R>(
     public fun writeSuccessfulResponse(
         response: LoginResponse.ReconnectOk,
         loginBlock: LoginBlock<*>,
-    ): Session<R>? {
+    ): Session<R> {
         // Ensure it isn't null - our decoder pre-validates it long before hitting this function,
         // so this exception should never be hit.
         val oldSchoolClientType =
             checkNotNull(loginBlock.clientType.toOldSchoolClientType()) {
                 "Login client type cannot be null"
             }
-        if (!ctx.channel().isActive) {
-            networkLog(logger) {
-                "Channel '${ctx.channel()}' has gone inactive; login block: $loginBlock"
-            }
-            return null
-        }
         val (encodingCipher, decodingCipher) = createStreamCipherPair(loginBlock)
 
         // Unlike in the above case, we kind of have to assume it was successful

--- a/protocol/osrs-223/osrs-223-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-223/osrs-223-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -20,7 +20,6 @@ import net.rsprot.protocol.api.game.GameMessageHandler
 import net.rsprot.protocol.api.logging.networkLog
 import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.loginprot.incoming.util.LoginBlock
-import net.rsprot.protocol.loginprot.incoming.util.LoginClientType
 import net.rsprot.protocol.loginprot.outgoing.LoginResponse
 import java.util.concurrent.TimeUnit
 
@@ -44,18 +43,12 @@ public class GameLoginResponseHandler<R>(
         response: LoginResponse.Ok,
         loginBlock: LoginBlock<*>,
     ): Session<R>? {
+        // Ensure it isn't null - our decoder pre-validates it long before hitting this function,
+        // so this exception should never be hit.
         val oldSchoolClientType =
-            getOldSchoolClientType(loginBlock)
-        if (oldSchoolClientType == null || !networkService.isSupported(oldSchoolClientType)) {
-            networkLog(logger) {
-                "Unsupported client type received from channel " +
-                    "'${ctx.channel()}': $oldSchoolClientType, login block: $loginBlock"
+            checkNotNull(loginBlock.clientType.toOldSchoolClientType()) {
+                "Login client type cannot be null"
             }
-            ctx
-                .writeAndFlush(LoginResponse.InvalidLoginPacket)
-                .addListener(ChannelFutureListener.CLOSE)
-            return null
-        }
         if (!ctx.channel().isActive) {
             networkLog(logger) {
                 "Channel '${ctx.channel()}' has gone inactive; login block: $loginBlock"
@@ -113,16 +106,12 @@ public class GameLoginResponseHandler<R>(
         response: LoginResponse.ReconnectOk,
         loginBlock: LoginBlock<*>,
     ): Session<R>? {
+        // Ensure it isn't null - our decoder pre-validates it long before hitting this function,
+        // so this exception should never be hit.
         val oldSchoolClientType =
-            getOldSchoolClientType(loginBlock)
-        if (oldSchoolClientType == null || !networkService.isSupported(oldSchoolClientType)) {
-            networkLog(logger) {
-                "Unsupported client type received from channel " +
-                    "'${ctx.channel()}': $oldSchoolClientType, login block: $loginBlock"
+            checkNotNull(loginBlock.clientType.toOldSchoolClientType()) {
+                "Login client type cannot be null"
             }
-            ctx.writeAndFlush(LoginResponse.InvalidLoginPacket)
-            return null
-        }
         if (!ctx.channel().isActive) {
             networkLog(logger) {
                 "Channel '${ctx.channel()}' has gone inactive; login block: $loginBlock"
@@ -155,20 +144,6 @@ public class GameLoginResponseHandler<R>(
         val encodingCipher = provider.provide(decodeSeed)
         val decodingCipher = provider.provide(encodeSeed)
         return StreamCipherPair(encodingCipher, decodingCipher)
-    }
-
-    private fun getOldSchoolClientType(loginBlock: LoginBlock<*>): OldSchoolClientType? {
-        val oldSchoolClientType =
-            when (loginBlock.clientType) {
-                LoginClientType.DESKTOP -> OldSchoolClientType.DESKTOP
-                LoginClientType.ENHANCED_WINDOWS -> OldSchoolClientType.DESKTOP
-                LoginClientType.ENHANCED_LINUX -> OldSchoolClientType.DESKTOP
-                LoginClientType.ENHANCED_MAC -> OldSchoolClientType.DESKTOP
-                LoginClientType.ENHANCED_ANDROID -> OldSchoolClientType.ANDROID
-                LoginClientType.ENHANCED_IOS -> OldSchoolClientType.IOS
-                else -> null
-            }
-        return oldSchoolClientType
     }
 
     private fun createSession(

--- a/protocol/osrs-223/osrs-223-api/src/main/kotlin/net/rsprot/protocol/api/repositories/MessageDecoderRepositories.kt
+++ b/protocol/osrs-223/osrs-223-api/src/main/kotlin/net/rsprot/protocol/api/repositories/MessageDecoderRepositories.kt
@@ -22,11 +22,12 @@ public class MessageDecoderRepositories private constructor(
     public val gameMessageDecoderRepositories: ClientTypeMap<MessageDecoderRepository<ClientProt>>,
 ) {
     public constructor(
+        clientTypes: List<OldSchoolClientType>,
         exp: BigInteger,
         mod: BigInteger,
         gameMessageDecoderRepositories: ClientTypeMap<MessageDecoderRepository<ClientProt>>,
     ) : this(
-        LoginMessageDecoderRepository.build(exp, mod),
+        LoginMessageDecoderRepository.build(clientTypes, exp, mod),
         Js5MessageDecoderRepository.build(),
         gameMessageDecoderRepositories,
     )
@@ -49,6 +50,7 @@ public class MessageDecoderRepositories private constructor(
                     repositories,
                 )
             return MessageDecoderRepositories(
+                clientTypes,
                 rsaKeyPair.exponent,
                 rsaKeyPair.modulus,
                 clientTypeMap,

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/LoginClientType.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/LoginClientType.kt
@@ -1,5 +1,7 @@
 package net.rsprot.protocol.loginprot.incoming.util
 
+import net.rsprot.protocol.common.client.OldSchoolClientType
+
 public enum class LoginClientType(
     public val id: Int,
 ) {
@@ -12,6 +14,18 @@ public enum class LoginClientType(
     ENHANCED_IOS(8),
     ENHANCED_LINUX(10),
     ;
+
+    public fun toOldSchoolClientType(): OldSchoolClientType? {
+        return when (this) {
+            DESKTOP -> OldSchoolClientType.DESKTOP
+            ENHANCED_WINDOWS -> OldSchoolClientType.DESKTOP
+            ENHANCED_LINUX -> OldSchoolClientType.DESKTOP
+            ENHANCED_MAC -> OldSchoolClientType.DESKTOP
+            ENHANCED_ANDROID -> OldSchoolClientType.ANDROID
+            ENHANCED_IOS -> OldSchoolClientType.IOS
+            else -> null
+        }
+    }
 
     public companion object {
         public operator fun get(id: Int): LoginClientType =

--- a/protocol/osrs-223/osrs-223-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameLoginDecoder.kt
+++ b/protocol/osrs-223/osrs-223-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameLoginDecoder.kt
@@ -3,6 +3,7 @@ package net.rsprot.protocol.common.loginprot.incoming.codec
 import net.rsprot.buffer.JagByteBuf
 import net.rsprot.buffer.extensions.toJagByteBuf
 import net.rsprot.protocol.ClientProt
+import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.common.loginprot.incoming.codec.shared.LoginBlockDecoder
 import net.rsprot.protocol.common.loginprot.incoming.prot.LoginClientProt
 import net.rsprot.protocol.loginprot.incoming.GameLogin
@@ -14,6 +15,7 @@ import net.rsprot.protocol.message.codec.MessageDecoder
 import java.math.BigInteger
 
 public class GameLoginDecoder(
+    private val supportedClientTypes: List<OldSchoolClientType>,
     exp: BigInteger,
     mod: BigInteger,
 ) : LoginBlockDecoder<AuthenticationType<*>>(exp, mod),
@@ -25,7 +27,7 @@ public class GameLoginDecoder(
         // Mark the buffer as "read" as copy function doesn't do it automatically.
         buffer.buffer.readerIndex(buffer.buffer.writerIndex())
         return GameLogin(copy.toJagByteBuf()) { jagByteBuf, betaWorld ->
-            decodeLoginBlock(jagByteBuf, betaWorld)
+            decodeLoginBlock(jagByteBuf, betaWorld, supportedClientTypes)
         }
     }
 

--- a/protocol/osrs-223/osrs-223-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameReconnectDecoder.kt
+++ b/protocol/osrs-223/osrs-223-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameReconnectDecoder.kt
@@ -4,6 +4,7 @@ import net.rsprot.buffer.JagByteBuf
 import net.rsprot.buffer.extensions.toJagByteBuf
 import net.rsprot.crypto.xtea.XteaKey
 import net.rsprot.protocol.ClientProt
+import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.common.loginprot.incoming.codec.shared.LoginBlockDecoder
 import net.rsprot.protocol.common.loginprot.incoming.prot.LoginClientProt
 import net.rsprot.protocol.loginprot.incoming.GameReconnect
@@ -11,6 +12,7 @@ import net.rsprot.protocol.message.codec.MessageDecoder
 import java.math.BigInteger
 
 public class GameReconnectDecoder(
+    private val supportedClientTypes: List<OldSchoolClientType>,
     exp: BigInteger,
     mod: BigInteger,
 ) : LoginBlockDecoder<XteaKey>(exp, mod),
@@ -22,7 +24,7 @@ public class GameReconnectDecoder(
         // Mark the buffer as "read" as copy function doesn't do it automatically.
         buffer.buffer.readerIndex(buffer.buffer.writerIndex())
         return GameReconnect(copy.toJagByteBuf()) { jagByteBuf, betaWorld ->
-            decodeLoginBlock(jagByteBuf, betaWorld)
+            decodeLoginBlock(jagByteBuf, betaWorld, supportedClientTypes)
         }
     }
 

--- a/protocol/osrs-223/osrs-223-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/shared/exceptions/UnsupportedClientException.kt
+++ b/protocol/osrs-223/osrs-223-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/shared/exceptions/UnsupportedClientException.kt
@@ -1,0 +1,12 @@
+package net.rsprot.protocol.common.loginprot.incoming.codec.shared.exceptions
+
+/**
+ * A singleton exception for whenever login decoding fails due to an unsupported client connecting to it.
+ * It is not ideal to be using exceptions for flow control, but it is by far the easiest option
+ * here. From a performance standpoint, only building stack traces is slow, which we aren't
+ * going to be doing for this type of exception.
+ */
+public data object UnsupportedClientException : RuntimeException() {
+    @Suppress("unused")
+    private fun readResolve(): Any = UnsupportedClientException
+}

--- a/protocol/osrs-223/osrs-223-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/prot/LoginMessageDecoderRepository.kt
+++ b/protocol/osrs-223/osrs-223-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/prot/LoginMessageDecoderRepository.kt
@@ -1,6 +1,7 @@
 package net.rsprot.protocol.common.loginprot.incoming.prot
 
 import net.rsprot.protocol.ProtRepository
+import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.common.loginprot.incoming.codec.GameLoginDecoder
 import net.rsprot.protocol.common.loginprot.incoming.codec.GameReconnectDecoder
 import net.rsprot.protocol.common.loginprot.incoming.codec.InitGameConnectionDecoder
@@ -14,6 +15,7 @@ import java.math.BigInteger
 public object LoginMessageDecoderRepository {
     @ExperimentalStdlibApi
     public fun build(
+        supportedClientTypes: List<OldSchoolClientType>,
         exp: BigInteger,
         mod: BigInteger,
     ): MessageDecoderRepository<LoginClientProt> {
@@ -24,8 +26,8 @@ public object LoginMessageDecoderRepository {
             ).apply {
                 bind(InitGameConnectionDecoder())
                 bind(InitJs5RemoteConnectionDecoder())
-                bind(GameLoginDecoder(exp, mod))
-                bind(GameReconnectDecoder(exp, mod))
+                bind(GameLoginDecoder(supportedClientTypes, exp, mod))
+                bind(GameReconnectDecoder(supportedClientTypes, exp, mod))
                 bind(ProofOfWorkReplyDecoder())
                 bind(RemainingBetaArchivesDecoder())
             }

--- a/protocol/osrs-224/osrs-224-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-224/osrs-224-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -49,12 +49,6 @@ public class GameLoginResponseHandler<R>(
             checkNotNull(loginBlock.clientType.toOldSchoolClientType()) {
                 "Login client type cannot be null"
             }
-        if (!ctx.channel().isActive) {
-            networkLog(logger) {
-                "Channel '${ctx.channel()}' has gone inactive; login block: $loginBlock"
-            }
-            return null
-        }
         val address = ctx.inetAddress()
         val count =
             networkService
@@ -105,19 +99,13 @@ public class GameLoginResponseHandler<R>(
     public fun writeSuccessfulResponse(
         response: LoginResponse.ReconnectOk,
         loginBlock: LoginBlock<*>,
-    ): Session<R>? {
+    ): Session<R> {
         // Ensure it isn't null - our decoder pre-validates it long before hitting this function,
         // so this exception should never be hit.
         val oldSchoolClientType =
             checkNotNull(loginBlock.clientType.toOldSchoolClientType()) {
                 "Login client type cannot be null"
             }
-        if (!ctx.channel().isActive) {
-            networkLog(logger) {
-                "Channel '${ctx.channel()}' has gone inactive; login block: $loginBlock"
-            }
-            return null
-        }
         val (encodingCipher, decodingCipher) = createStreamCipherPair(loginBlock)
 
         // Unlike in the above case, we kind of have to assume it was successful

--- a/protocol/osrs-224/osrs-224-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-224/osrs-224-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -20,7 +20,6 @@ import net.rsprot.protocol.api.game.GameMessageHandler
 import net.rsprot.protocol.api.logging.networkLog
 import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.loginprot.incoming.util.LoginBlock
-import net.rsprot.protocol.loginprot.incoming.util.LoginClientType
 import net.rsprot.protocol.loginprot.outgoing.LoginResponse
 import java.util.concurrent.TimeUnit
 
@@ -44,18 +43,12 @@ public class GameLoginResponseHandler<R>(
         response: LoginResponse.Ok,
         loginBlock: LoginBlock<*>,
     ): Session<R>? {
+        // Ensure it isn't null - our decoder pre-validates it long before hitting this function,
+        // so this exception should never be hit.
         val oldSchoolClientType =
-            getOldSchoolClientType(loginBlock)
-        if (oldSchoolClientType == null || !networkService.isSupported(oldSchoolClientType)) {
-            networkLog(logger) {
-                "Unsupported client type received from channel " +
-                    "'${ctx.channel()}': $oldSchoolClientType, login block: $loginBlock"
+            checkNotNull(loginBlock.clientType.toOldSchoolClientType()) {
+                "Login client type cannot be null"
             }
-            ctx
-                .writeAndFlush(LoginResponse.InvalidLoginPacket)
-                .addListener(ChannelFutureListener.CLOSE)
-            return null
-        }
         if (!ctx.channel().isActive) {
             networkLog(logger) {
                 "Channel '${ctx.channel()}' has gone inactive; login block: $loginBlock"
@@ -113,16 +106,12 @@ public class GameLoginResponseHandler<R>(
         response: LoginResponse.ReconnectOk,
         loginBlock: LoginBlock<*>,
     ): Session<R>? {
+        // Ensure it isn't null - our decoder pre-validates it long before hitting this function,
+        // so this exception should never be hit.
         val oldSchoolClientType =
-            getOldSchoolClientType(loginBlock)
-        if (oldSchoolClientType == null || !networkService.isSupported(oldSchoolClientType)) {
-            networkLog(logger) {
-                "Unsupported client type received from channel " +
-                    "'${ctx.channel()}': $oldSchoolClientType, login block: $loginBlock"
+            checkNotNull(loginBlock.clientType.toOldSchoolClientType()) {
+                "Login client type cannot be null"
             }
-            ctx.writeAndFlush(LoginResponse.InvalidLoginPacket)
-            return null
-        }
         if (!ctx.channel().isActive) {
             networkLog(logger) {
                 "Channel '${ctx.channel()}' has gone inactive; login block: $loginBlock"
@@ -155,20 +144,6 @@ public class GameLoginResponseHandler<R>(
         val encodingCipher = provider.provide(decodeSeed)
         val decodingCipher = provider.provide(encodeSeed)
         return StreamCipherPair(encodingCipher, decodingCipher)
-    }
-
-    private fun getOldSchoolClientType(loginBlock: LoginBlock<*>): OldSchoolClientType? {
-        val oldSchoolClientType =
-            when (loginBlock.clientType) {
-                LoginClientType.DESKTOP -> OldSchoolClientType.DESKTOP
-                LoginClientType.ENHANCED_WINDOWS -> OldSchoolClientType.DESKTOP
-                LoginClientType.ENHANCED_LINUX -> OldSchoolClientType.DESKTOP
-                LoginClientType.ENHANCED_MAC -> OldSchoolClientType.DESKTOP
-                LoginClientType.ENHANCED_ANDROID -> OldSchoolClientType.ANDROID
-                LoginClientType.ENHANCED_IOS -> OldSchoolClientType.IOS
-                else -> null
-            }
-        return oldSchoolClientType
     }
 
     private fun createSession(

--- a/protocol/osrs-224/osrs-224-api/src/main/kotlin/net/rsprot/protocol/api/repositories/MessageDecoderRepositories.kt
+++ b/protocol/osrs-224/osrs-224-api/src/main/kotlin/net/rsprot/protocol/api/repositories/MessageDecoderRepositories.kt
@@ -22,11 +22,12 @@ public class MessageDecoderRepositories private constructor(
     public val gameMessageDecoderRepositories: ClientTypeMap<MessageDecoderRepository<ClientProt>>,
 ) {
     public constructor(
+        clientTypes: List<OldSchoolClientType>,
         exp: BigInteger,
         mod: BigInteger,
         gameMessageDecoderRepositories: ClientTypeMap<MessageDecoderRepository<ClientProt>>,
     ) : this(
-        LoginMessageDecoderRepository.build(exp, mod),
+        LoginMessageDecoderRepository.build(clientTypes, exp, mod),
         Js5MessageDecoderRepository.build(),
         gameMessageDecoderRepositories,
     )
@@ -49,6 +50,7 @@ public class MessageDecoderRepositories private constructor(
                     repositories,
                 )
             return MessageDecoderRepositories(
+                clientTypes,
                 rsaKeyPair.exponent,
                 rsaKeyPair.modulus,
                 clientTypeMap,

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/LoginClientType.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/LoginClientType.kt
@@ -1,5 +1,7 @@
 package net.rsprot.protocol.loginprot.incoming.util
 
+import net.rsprot.protocol.common.client.OldSchoolClientType
+
 public enum class LoginClientType(
     public val id: Int,
 ) {
@@ -12,6 +14,18 @@ public enum class LoginClientType(
     ENHANCED_IOS(8),
     ENHANCED_LINUX(10),
     ;
+
+    public fun toOldSchoolClientType(): OldSchoolClientType? {
+        return when (this) {
+            DESKTOP -> OldSchoolClientType.DESKTOP
+            ENHANCED_WINDOWS -> OldSchoolClientType.DESKTOP
+            ENHANCED_LINUX -> OldSchoolClientType.DESKTOP
+            ENHANCED_MAC -> OldSchoolClientType.DESKTOP
+            ENHANCED_ANDROID -> OldSchoolClientType.ANDROID
+            ENHANCED_IOS -> OldSchoolClientType.IOS
+            else -> null
+        }
+    }
 
     public companion object {
         public operator fun get(id: Int): LoginClientType =

--- a/protocol/osrs-224/osrs-224-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameLoginDecoder.kt
+++ b/protocol/osrs-224/osrs-224-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameLoginDecoder.kt
@@ -3,6 +3,7 @@ package net.rsprot.protocol.common.loginprot.incoming.codec
 import net.rsprot.buffer.JagByteBuf
 import net.rsprot.buffer.extensions.toJagByteBuf
 import net.rsprot.protocol.ClientProt
+import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.common.loginprot.incoming.codec.shared.LoginBlockDecoder
 import net.rsprot.protocol.common.loginprot.incoming.prot.LoginClientProt
 import net.rsprot.protocol.loginprot.incoming.GameLogin
@@ -14,6 +15,7 @@ import net.rsprot.protocol.message.codec.MessageDecoder
 import java.math.BigInteger
 
 public class GameLoginDecoder(
+    private val supportedClientTypes: List<OldSchoolClientType>,
     exp: BigInteger,
     mod: BigInteger,
 ) : LoginBlockDecoder<AuthenticationType<*>>(exp, mod),
@@ -25,7 +27,7 @@ public class GameLoginDecoder(
         // Mark the buffer as "read" as copy function doesn't do it automatically.
         buffer.buffer.readerIndex(buffer.buffer.writerIndex())
         return GameLogin(copy.toJagByteBuf()) { jagByteBuf, betaWorld ->
-            decodeLoginBlock(jagByteBuf, betaWorld)
+            decodeLoginBlock(jagByteBuf, betaWorld, supportedClientTypes)
         }
     }
 

--- a/protocol/osrs-224/osrs-224-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameReconnectDecoder.kt
+++ b/protocol/osrs-224/osrs-224-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameReconnectDecoder.kt
@@ -4,6 +4,7 @@ import net.rsprot.buffer.JagByteBuf
 import net.rsprot.buffer.extensions.toJagByteBuf
 import net.rsprot.crypto.xtea.XteaKey
 import net.rsprot.protocol.ClientProt
+import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.common.loginprot.incoming.codec.shared.LoginBlockDecoder
 import net.rsprot.protocol.common.loginprot.incoming.prot.LoginClientProt
 import net.rsprot.protocol.loginprot.incoming.GameReconnect
@@ -11,6 +12,7 @@ import net.rsprot.protocol.message.codec.MessageDecoder
 import java.math.BigInteger
 
 public class GameReconnectDecoder(
+    private val supportedClientTypes: List<OldSchoolClientType>,
     exp: BigInteger,
     mod: BigInteger,
 ) : LoginBlockDecoder<XteaKey>(exp, mod),
@@ -22,7 +24,7 @@ public class GameReconnectDecoder(
         // Mark the buffer as "read" as copy function doesn't do it automatically.
         buffer.buffer.readerIndex(buffer.buffer.writerIndex())
         return GameReconnect(copy.toJagByteBuf()) { jagByteBuf, betaWorld ->
-            decodeLoginBlock(jagByteBuf, betaWorld)
+            decodeLoginBlock(jagByteBuf, betaWorld, supportedClientTypes)
         }
     }
 

--- a/protocol/osrs-224/osrs-224-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/shared/exceptions/UnsupportedClientException.kt
+++ b/protocol/osrs-224/osrs-224-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/shared/exceptions/UnsupportedClientException.kt
@@ -1,0 +1,12 @@
+package net.rsprot.protocol.common.loginprot.incoming.codec.shared.exceptions
+
+/**
+ * A singleton exception for whenever login decoding fails due to an unsupported client connecting to it.
+ * It is not ideal to be using exceptions for flow control, but it is by far the easiest option
+ * here. From a performance standpoint, only building stack traces is slow, which we aren't
+ * going to be doing for this type of exception.
+ */
+public data object UnsupportedClientException : RuntimeException() {
+    @Suppress("unused")
+    private fun readResolve(): Any = UnsupportedClientException
+}

--- a/protocol/osrs-224/osrs-224-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/prot/LoginMessageDecoderRepository.kt
+++ b/protocol/osrs-224/osrs-224-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/prot/LoginMessageDecoderRepository.kt
@@ -1,6 +1,7 @@
 package net.rsprot.protocol.common.loginprot.incoming.prot
 
 import net.rsprot.protocol.ProtRepository
+import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.common.loginprot.incoming.codec.GameLoginDecoder
 import net.rsprot.protocol.common.loginprot.incoming.codec.GameReconnectDecoder
 import net.rsprot.protocol.common.loginprot.incoming.codec.InitGameConnectionDecoder
@@ -14,6 +15,7 @@ import java.math.BigInteger
 public object LoginMessageDecoderRepository {
     @ExperimentalStdlibApi
     public fun build(
+        supportedClientTypes: List<OldSchoolClientType>,
         exp: BigInteger,
         mod: BigInteger,
     ): MessageDecoderRepository<LoginClientProt> {
@@ -24,8 +26,8 @@ public object LoginMessageDecoderRepository {
             ).apply {
                 bind(InitGameConnectionDecoder())
                 bind(InitJs5RemoteConnectionDecoder())
-                bind(GameLoginDecoder(exp, mod))
-                bind(GameReconnectDecoder(exp, mod))
+                bind(GameLoginDecoder(supportedClientTypes, exp, mod))
+                bind(GameReconnectDecoder(supportedClientTypes, exp, mod))
                 bind(ProofOfWorkReplyDecoder())
                 bind(RemainingBetaArchivesDecoder())
             }

--- a/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -35,6 +35,26 @@ public class GameLoginResponseHandler<R>(
     public val ctx: ChannelHandlerContext,
 ) {
     /**
+     * Validates the new connection by ensuring the connected user hasn't reached an IP limitation due
+     * to too many connections from the same IP.
+     * This function does not write any response to the client. It simply returns whether a new connection
+     * is allowed to take place. The server is responsible for writing the [LoginResponse.TooManyAttempts]
+     * response back to the client via [writeFailedResponse], should they wish to do so.
+     */
+    public fun validateNewConnection(): Boolean {
+        val address = ctx.inetAddress()
+        val count =
+            networkService
+                .iNetAddressHandlers
+                .gameInetAddressTracker
+                .getCount(address)
+        return networkService
+            .iNetAddressHandlers
+            .inetAddressValidator
+            .acceptGameConnection(address, count)
+    }
+
+    /**
      * Writes a successful login response to the client.
      * @param response the login response to write
      * @param loginBlock the login request that the client initially made
@@ -43,38 +63,13 @@ public class GameLoginResponseHandler<R>(
     public fun writeSuccessfulResponse(
         response: LoginResponse.Ok,
         loginBlock: LoginBlock<*>,
-    ): Session<R>? {
+    ): Session<R> {
         // Ensure it isn't null - our decoder pre-validates it long before hitting this function,
         // so this exception should never be hit.
         val oldSchoolClientType =
             checkNotNull(loginBlock.clientType.toOldSchoolClientType()) {
                 "Login client type cannot be null"
             }
-        val address = ctx.inetAddress()
-        val count =
-            networkService
-                .iNetAddressHandlers
-                .gameInetAddressTracker
-                .getCount(address)
-        val accepted =
-            networkService
-                .iNetAddressHandlers
-                .inetAddressValidator
-                .acceptGameConnection(address, count)
-        // Secondary validation just before we allow the server to log the user in
-        if (!accepted) {
-            networkLog(logger) {
-                "INetAddressValidator rejected game login for channel ${ctx.channel()}"
-            }
-            ctx
-                .writeAndFlush(LoginResponse.TooManyAttempts)
-                .addListener(ChannelFutureListener.CLOSE)
-            networkService.trafficMonitor.loginChannelTrafficMonitor.addDisconnectionReason(
-                ctx.inetAddress(),
-                LoginDisconnectionReason.GAME_TOO_MANY_ATTEMPTS,
-            )
-            return null
-        }
         val cipher = createStreamCipherPair(loginBlock)
 
         if (networkService.betaWorld) {

--- a/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -50,16 +50,6 @@ public class GameLoginResponseHandler<R>(
             checkNotNull(loginBlock.clientType.toOldSchoolClientType()) {
                 "Login client type cannot be null"
             }
-        if (!ctx.channel().isActive) {
-            networkLog(logger) {
-                "Channel '${ctx.channel()}' has gone inactive; login block: $loginBlock"
-            }
-            networkService.trafficMonitor.loginChannelTrafficMonitor.addDisconnectionReason(
-                ctx.inetAddress(),
-                LoginDisconnectionReason.GAME_CHANNEL_INACTIVE,
-            )
-            return null
-        }
         val address = ctx.inetAddress()
         val count =
             networkService
@@ -114,23 +104,13 @@ public class GameLoginResponseHandler<R>(
     public fun writeSuccessfulResponse(
         response: LoginResponse.ReconnectOk,
         loginBlock: LoginBlock<*>,
-    ): Session<R>? {
+    ): Session<R> {
         // Ensure it isn't null - our decoder pre-validates it long before hitting this function,
         // so this exception should never be hit.
         val oldSchoolClientType =
             checkNotNull(loginBlock.clientType.toOldSchoolClientType()) {
                 "Login client type cannot be null"
             }
-        if (!ctx.channel().isActive) {
-            networkLog(logger) {
-                "Channel '${ctx.channel()}' has gone inactive; login block: $loginBlock"
-            }
-            networkService.trafficMonitor.loginChannelTrafficMonitor.addDisconnectionReason(
-                ctx.inetAddress(),
-                LoginDisconnectionReason.GAME_CHANNEL_INACTIVE,
-            )
-            return null
-        }
         val (encodingCipher, decodingCipher) = createStreamCipherPair(loginBlock)
 
         // Unlike in the above case, we kind of have to assume it was successful

--- a/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/repositories/MessageDecoderRepositories.kt
+++ b/protocol/osrs-225/osrs-225-api/src/main/kotlin/net/rsprot/protocol/api/repositories/MessageDecoderRepositories.kt
@@ -22,11 +22,12 @@ public class MessageDecoderRepositories private constructor(
     public val gameMessageDecoderRepositories: ClientTypeMap<MessageDecoderRepository<ClientProt>>,
 ) {
     public constructor(
+        clientTypes: List<OldSchoolClientType>,
         exp: BigInteger,
         mod: BigInteger,
         gameMessageDecoderRepositories: ClientTypeMap<MessageDecoderRepository<ClientProt>>,
     ) : this(
-        LoginMessageDecoderRepository.build(exp, mod),
+        LoginMessageDecoderRepository.build(clientTypes, exp, mod),
         Js5MessageDecoderRepository.build(),
         gameMessageDecoderRepositories,
     )
@@ -49,6 +50,7 @@ public class MessageDecoderRepositories private constructor(
                     repositories,
                 )
             return MessageDecoderRepositories(
+                clientTypes,
                 rsaKeyPair.exponent,
                 rsaKeyPair.modulus,
                 clientTypeMap,

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/LoginClientType.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/LoginClientType.kt
@@ -1,5 +1,7 @@
 package net.rsprot.protocol.loginprot.incoming.util
 
+import net.rsprot.protocol.common.client.OldSchoolClientType
+
 public enum class LoginClientType(
     public val id: Int,
 ) {
@@ -12,6 +14,18 @@ public enum class LoginClientType(
     ENHANCED_IOS(8),
     ENHANCED_LINUX(10),
     ;
+
+    public fun toOldSchoolClientType(): OldSchoolClientType? {
+        return when (this) {
+            DESKTOP -> OldSchoolClientType.DESKTOP
+            ENHANCED_WINDOWS -> OldSchoolClientType.DESKTOP
+            ENHANCED_LINUX -> OldSchoolClientType.DESKTOP
+            ENHANCED_MAC -> OldSchoolClientType.DESKTOP
+            ENHANCED_ANDROID -> OldSchoolClientType.ANDROID
+            ENHANCED_IOS -> OldSchoolClientType.IOS
+            else -> null
+        }
+    }
 
     public companion object {
         public operator fun get(id: Int): LoginClientType =

--- a/protocol/osrs-225/osrs-225-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameLoginDecoder.kt
+++ b/protocol/osrs-225/osrs-225-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameLoginDecoder.kt
@@ -3,6 +3,7 @@ package net.rsprot.protocol.common.loginprot.incoming.codec
 import net.rsprot.buffer.JagByteBuf
 import net.rsprot.buffer.extensions.toJagByteBuf
 import net.rsprot.protocol.ClientProt
+import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.common.loginprot.incoming.codec.shared.LoginBlockDecoder
 import net.rsprot.protocol.common.loginprot.incoming.prot.LoginClientProt
 import net.rsprot.protocol.loginprot.incoming.GameLogin
@@ -14,6 +15,7 @@ import net.rsprot.protocol.message.codec.MessageDecoder
 import java.math.BigInteger
 
 public class GameLoginDecoder(
+    private val supportedClientTypes: List<OldSchoolClientType>,
     exp: BigInteger,
     mod: BigInteger,
 ) : LoginBlockDecoder<AuthenticationType<*>>(exp, mod),
@@ -25,7 +27,7 @@ public class GameLoginDecoder(
         // Mark the buffer as "read" as copy function doesn't do it automatically.
         buffer.buffer.readerIndex(buffer.buffer.writerIndex())
         return GameLogin(copy.toJagByteBuf()) { jagByteBuf, betaWorld ->
-            decodeLoginBlock(jagByteBuf, betaWorld)
+            decodeLoginBlock(jagByteBuf, betaWorld, supportedClientTypes)
         }
     }
 

--- a/protocol/osrs-225/osrs-225-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameReconnectDecoder.kt
+++ b/protocol/osrs-225/osrs-225-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameReconnectDecoder.kt
@@ -4,6 +4,7 @@ import net.rsprot.buffer.JagByteBuf
 import net.rsprot.buffer.extensions.toJagByteBuf
 import net.rsprot.crypto.xtea.XteaKey
 import net.rsprot.protocol.ClientProt
+import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.common.loginprot.incoming.codec.shared.LoginBlockDecoder
 import net.rsprot.protocol.common.loginprot.incoming.prot.LoginClientProt
 import net.rsprot.protocol.loginprot.incoming.GameReconnect
@@ -11,6 +12,7 @@ import net.rsprot.protocol.message.codec.MessageDecoder
 import java.math.BigInteger
 
 public class GameReconnectDecoder(
+    private val supportedClientTypes: List<OldSchoolClientType>,
     exp: BigInteger,
     mod: BigInteger,
 ) : LoginBlockDecoder<XteaKey>(exp, mod),
@@ -22,7 +24,7 @@ public class GameReconnectDecoder(
         // Mark the buffer as "read" as copy function doesn't do it automatically.
         buffer.buffer.readerIndex(buffer.buffer.writerIndex())
         return GameReconnect(copy.toJagByteBuf()) { jagByteBuf, betaWorld ->
-            decodeLoginBlock(jagByteBuf, betaWorld)
+            decodeLoginBlock(jagByteBuf, betaWorld, supportedClientTypes)
         }
     }
 

--- a/protocol/osrs-225/osrs-225-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/shared/exceptions/UnsupportedClientException.kt
+++ b/protocol/osrs-225/osrs-225-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/shared/exceptions/UnsupportedClientException.kt
@@ -1,0 +1,12 @@
+package net.rsprot.protocol.common.loginprot.incoming.codec.shared.exceptions
+
+/**
+ * A singleton exception for whenever login decoding fails due to an unsupported client connecting to it.
+ * It is not ideal to be using exceptions for flow control, but it is by far the easiest option
+ * here. From a performance standpoint, only building stack traces is slow, which we aren't
+ * going to be doing for this type of exception.
+ */
+public data object UnsupportedClientException : RuntimeException() {
+    @Suppress("unused")
+    private fun readResolve(): Any = UnsupportedClientException
+}

--- a/protocol/osrs-225/osrs-225-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/prot/LoginMessageDecoderRepository.kt
+++ b/protocol/osrs-225/osrs-225-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/prot/LoginMessageDecoderRepository.kt
@@ -1,6 +1,7 @@
 package net.rsprot.protocol.common.loginprot.incoming.prot
 
 import net.rsprot.protocol.ProtRepository
+import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.common.loginprot.incoming.codec.GameLoginDecoder
 import net.rsprot.protocol.common.loginprot.incoming.codec.GameReconnectDecoder
 import net.rsprot.protocol.common.loginprot.incoming.codec.InitGameConnectionDecoder
@@ -14,6 +15,7 @@ import java.math.BigInteger
 public object LoginMessageDecoderRepository {
     @ExperimentalStdlibApi
     public fun build(
+        supportedClientTypes: List<OldSchoolClientType>,
         exp: BigInteger,
         mod: BigInteger,
     ): MessageDecoderRepository<LoginClientProt> {
@@ -24,8 +26,8 @@ public object LoginMessageDecoderRepository {
             ).apply {
                 bind(InitGameConnectionDecoder())
                 bind(InitJs5RemoteConnectionDecoder())
-                bind(GameLoginDecoder(exp, mod))
-                bind(GameReconnectDecoder(exp, mod))
+                bind(GameLoginDecoder(supportedClientTypes, exp, mod))
+                bind(GameReconnectDecoder(supportedClientTypes, exp, mod))
                 bind(ProofOfWorkReplyDecoder())
                 bind(RemainingBetaArchivesDecoder())
             }

--- a/protocol/osrs-226/osrs-226-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-226/osrs-226-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -35,6 +35,26 @@ public class GameLoginResponseHandler<R>(
     public val ctx: ChannelHandlerContext,
 ) {
     /**
+     * Validates the new connection by ensuring the connected user hasn't reached an IP limitation due
+     * to too many connections from the same IP.
+     * This function does not write any response to the client. It simply returns whether a new connection
+     * is allowed to take place. The server is responsible for writing the [LoginResponse.TooManyAttempts]
+     * response back to the client via [writeFailedResponse], should they wish to do so.
+     */
+    public fun validateNewConnection(): Boolean {
+        val address = ctx.inetAddress()
+        val count =
+            networkService
+                .iNetAddressHandlers
+                .gameInetAddressTracker
+                .getCount(address)
+        return networkService
+            .iNetAddressHandlers
+            .inetAddressValidator
+            .acceptGameConnection(address, count)
+    }
+
+    /**
      * Writes a successful login response to the client.
      * @param response the login response to write
      * @param loginBlock the login request that the client initially made
@@ -43,38 +63,13 @@ public class GameLoginResponseHandler<R>(
     public fun writeSuccessfulResponse(
         response: LoginResponse.Ok,
         loginBlock: LoginBlock<*>,
-    ): Session<R>? {
+    ): Session<R> {
         // Ensure it isn't null - our decoder pre-validates it long before hitting this function,
         // so this exception should never be hit.
         val oldSchoolClientType =
             checkNotNull(loginBlock.clientType.toOldSchoolClientType()) {
                 "Login client type cannot be null"
             }
-        val address = ctx.inetAddress()
-        val count =
-            networkService
-                .iNetAddressHandlers
-                .gameInetAddressTracker
-                .getCount(address)
-        val accepted =
-            networkService
-                .iNetAddressHandlers
-                .inetAddressValidator
-                .acceptGameConnection(address, count)
-        // Secondary validation just before we allow the server to log the user in
-        if (!accepted) {
-            networkLog(logger) {
-                "INetAddressValidator rejected game login for channel ${ctx.channel()}"
-            }
-            ctx
-                .writeAndFlush(LoginResponse.TooManyAttempts)
-                .addListener(ChannelFutureListener.CLOSE)
-            networkService.trafficMonitor.loginChannelTrafficMonitor.addDisconnectionReason(
-                ctx.inetAddress(),
-                LoginDisconnectionReason.GAME_TOO_MANY_ATTEMPTS,
-            )
-            return null
-        }
         val cipher = createStreamCipherPair(loginBlock)
 
         if (networkService.betaWorld) {

--- a/protocol/osrs-226/osrs-226-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-226/osrs-226-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -50,16 +50,6 @@ public class GameLoginResponseHandler<R>(
             checkNotNull(loginBlock.clientType.toOldSchoolClientType()) {
                 "Login client type cannot be null"
             }
-        if (!ctx.channel().isActive) {
-            networkLog(logger) {
-                "Channel '${ctx.channel()}' has gone inactive; login block: $loginBlock"
-            }
-            networkService.trafficMonitor.loginChannelTrafficMonitor.addDisconnectionReason(
-                ctx.inetAddress(),
-                LoginDisconnectionReason.GAME_CHANNEL_INACTIVE,
-            )
-            return null
-        }
         val address = ctx.inetAddress()
         val count =
             networkService
@@ -114,23 +104,13 @@ public class GameLoginResponseHandler<R>(
     public fun writeSuccessfulResponse(
         response: LoginResponse.ReconnectOk,
         loginBlock: LoginBlock<*>,
-    ): Session<R>? {
+    ): Session<R> {
         // Ensure it isn't null - our decoder pre-validates it long before hitting this function,
         // so this exception should never be hit.
         val oldSchoolClientType =
             checkNotNull(loginBlock.clientType.toOldSchoolClientType()) {
                 "Login client type cannot be null"
             }
-        if (!ctx.channel().isActive) {
-            networkLog(logger) {
-                "Channel '${ctx.channel()}' has gone inactive; login block: $loginBlock"
-            }
-            networkService.trafficMonitor.loginChannelTrafficMonitor.addDisconnectionReason(
-                ctx.inetAddress(),
-                LoginDisconnectionReason.GAME_CHANNEL_INACTIVE,
-            )
-            return null
-        }
         val (encodingCipher, decodingCipher) = createStreamCipherPair(loginBlock)
 
         // Unlike in the above case, we kind of have to assume it was successful

--- a/protocol/osrs-226/osrs-226-api/src/main/kotlin/net/rsprot/protocol/api/repositories/MessageDecoderRepositories.kt
+++ b/protocol/osrs-226/osrs-226-api/src/main/kotlin/net/rsprot/protocol/api/repositories/MessageDecoderRepositories.kt
@@ -22,11 +22,12 @@ public class MessageDecoderRepositories private constructor(
     public val gameMessageDecoderRepositories: ClientTypeMap<MessageDecoderRepository<ClientProt>>,
 ) {
     public constructor(
+        clientTypes: List<OldSchoolClientType>,
         exp: BigInteger,
         mod: BigInteger,
         gameMessageDecoderRepositories: ClientTypeMap<MessageDecoderRepository<ClientProt>>,
     ) : this(
-        LoginMessageDecoderRepository.build(exp, mod),
+        LoginMessageDecoderRepository.build(clientTypes, exp, mod),
         Js5MessageDecoderRepository.build(),
         gameMessageDecoderRepositories,
     )
@@ -49,6 +50,7 @@ public class MessageDecoderRepositories private constructor(
                     repositories,
                 )
             return MessageDecoderRepositories(
+                clientTypes,
                 rsaKeyPair.exponent,
                 rsaKeyPair.modulus,
                 clientTypeMap,

--- a/protocol/osrs-226/osrs-226-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/LoginClientType.kt
+++ b/protocol/osrs-226/osrs-226-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/LoginClientType.kt
@@ -1,5 +1,7 @@
 package net.rsprot.protocol.loginprot.incoming.util
 
+import net.rsprot.protocol.common.client.OldSchoolClientType
+
 public enum class LoginClientType(
     public val id: Int,
 ) {
@@ -12,6 +14,18 @@ public enum class LoginClientType(
     ENHANCED_IOS(8),
     ENHANCED_LINUX(10),
     ;
+
+    public fun toOldSchoolClientType(): OldSchoolClientType? {
+        return when (this) {
+            DESKTOP -> OldSchoolClientType.DESKTOP
+            ENHANCED_WINDOWS -> OldSchoolClientType.DESKTOP
+            ENHANCED_LINUX -> OldSchoolClientType.DESKTOP
+            ENHANCED_MAC -> OldSchoolClientType.DESKTOP
+            ENHANCED_ANDROID -> OldSchoolClientType.ANDROID
+            ENHANCED_IOS -> OldSchoolClientType.IOS
+            else -> null
+        }
+    }
 
     public companion object {
         public operator fun get(id: Int): LoginClientType =

--- a/protocol/osrs-226/osrs-226-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameLoginDecoder.kt
+++ b/protocol/osrs-226/osrs-226-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameLoginDecoder.kt
@@ -3,6 +3,7 @@ package net.rsprot.protocol.common.loginprot.incoming.codec
 import net.rsprot.buffer.JagByteBuf
 import net.rsprot.buffer.extensions.toJagByteBuf
 import net.rsprot.protocol.ClientProt
+import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.common.loginprot.incoming.codec.shared.LoginBlockDecoder
 import net.rsprot.protocol.common.loginprot.incoming.prot.LoginClientProt
 import net.rsprot.protocol.loginprot.incoming.GameLogin
@@ -14,6 +15,7 @@ import net.rsprot.protocol.message.codec.MessageDecoder
 import java.math.BigInteger
 
 public class GameLoginDecoder(
+    private val supportedClientTypes: List<OldSchoolClientType>,
     exp: BigInteger,
     mod: BigInteger,
 ) : LoginBlockDecoder<AuthenticationType<*>>(exp, mod),
@@ -25,7 +27,7 @@ public class GameLoginDecoder(
         // Mark the buffer as "read" as copy function doesn't do it automatically.
         buffer.buffer.readerIndex(buffer.buffer.writerIndex())
         return GameLogin(copy.toJagByteBuf()) { jagByteBuf, betaWorld ->
-            decodeLoginBlock(jagByteBuf, betaWorld)
+            decodeLoginBlock(jagByteBuf, betaWorld, supportedClientTypes)
         }
     }
 

--- a/protocol/osrs-226/osrs-226-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameReconnectDecoder.kt
+++ b/protocol/osrs-226/osrs-226-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameReconnectDecoder.kt
@@ -4,6 +4,7 @@ import net.rsprot.buffer.JagByteBuf
 import net.rsprot.buffer.extensions.toJagByteBuf
 import net.rsprot.crypto.xtea.XteaKey
 import net.rsprot.protocol.ClientProt
+import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.common.loginprot.incoming.codec.shared.LoginBlockDecoder
 import net.rsprot.protocol.common.loginprot.incoming.prot.LoginClientProt
 import net.rsprot.protocol.loginprot.incoming.GameReconnect
@@ -11,6 +12,7 @@ import net.rsprot.protocol.message.codec.MessageDecoder
 import java.math.BigInteger
 
 public class GameReconnectDecoder(
+    private val supportedClientTypes: List<OldSchoolClientType>,
     exp: BigInteger,
     mod: BigInteger,
 ) : LoginBlockDecoder<XteaKey>(exp, mod),
@@ -22,7 +24,7 @@ public class GameReconnectDecoder(
         // Mark the buffer as "read" as copy function doesn't do it automatically.
         buffer.buffer.readerIndex(buffer.buffer.writerIndex())
         return GameReconnect(copy.toJagByteBuf()) { jagByteBuf, betaWorld ->
-            decodeLoginBlock(jagByteBuf, betaWorld)
+            decodeLoginBlock(jagByteBuf, betaWorld, supportedClientTypes)
         }
     }
 

--- a/protocol/osrs-226/osrs-226-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/shared/exceptions/UnsupportedClientException.kt
+++ b/protocol/osrs-226/osrs-226-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/shared/exceptions/UnsupportedClientException.kt
@@ -1,0 +1,12 @@
+package net.rsprot.protocol.common.loginprot.incoming.codec.shared.exceptions
+
+/**
+ * A singleton exception for whenever login decoding fails due to an unsupported client connecting to it.
+ * It is not ideal to be using exceptions for flow control, but it is by far the easiest option
+ * here. From a performance standpoint, only building stack traces is slow, which we aren't
+ * going to be doing for this type of exception.
+ */
+public data object UnsupportedClientException : RuntimeException() {
+    @Suppress("unused")
+    private fun readResolve(): Any = UnsupportedClientException
+}

--- a/protocol/osrs-226/osrs-226-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/prot/LoginMessageDecoderRepository.kt
+++ b/protocol/osrs-226/osrs-226-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/prot/LoginMessageDecoderRepository.kt
@@ -1,6 +1,7 @@
 package net.rsprot.protocol.common.loginprot.incoming.prot
 
 import net.rsprot.protocol.ProtRepository
+import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.common.loginprot.incoming.codec.GameLoginDecoder
 import net.rsprot.protocol.common.loginprot.incoming.codec.GameReconnectDecoder
 import net.rsprot.protocol.common.loginprot.incoming.codec.InitGameConnectionDecoder
@@ -14,6 +15,7 @@ import java.math.BigInteger
 public object LoginMessageDecoderRepository {
     @ExperimentalStdlibApi
     public fun build(
+        supportedClientTypes: List<OldSchoolClientType>,
         exp: BigInteger,
         mod: BigInteger,
     ): MessageDecoderRepository<LoginClientProt> {
@@ -24,8 +26,8 @@ public object LoginMessageDecoderRepository {
             ).apply {
                 bind(InitGameConnectionDecoder())
                 bind(InitJs5RemoteConnectionDecoder())
-                bind(GameLoginDecoder(exp, mod))
-                bind(GameReconnectDecoder(exp, mod))
+                bind(GameLoginDecoder(supportedClientTypes, exp, mod))
+                bind(GameReconnectDecoder(supportedClientTypes, exp, mod))
                 bind(ProofOfWorkReplyDecoder())
                 bind(RemainingBetaArchivesDecoder())
             }

--- a/protocol/osrs-227/osrs-227-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-227/osrs-227-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -35,6 +35,26 @@ public class GameLoginResponseHandler<R>(
     public val ctx: ChannelHandlerContext,
 ) {
     /**
+     * Validates the new connection by ensuring the connected user hasn't reached an IP limitation due
+     * to too many connections from the same IP.
+     * This function does not write any response to the client. It simply returns whether a new connection
+     * is allowed to take place. The server is responsible for writing the [LoginResponse.TooManyAttempts]
+     * response back to the client via [writeFailedResponse], should they wish to do so.
+     */
+    public fun validateNewConnection(): Boolean {
+        val address = ctx.inetAddress()
+        val count =
+            networkService
+                .iNetAddressHandlers
+                .gameInetAddressTracker
+                .getCount(address)
+        return networkService
+            .iNetAddressHandlers
+            .inetAddressValidator
+            .acceptGameConnection(address, count)
+    }
+
+    /**
      * Writes a successful login response to the client.
      * @param response the login response to write
      * @param loginBlock the login request that the client initially made
@@ -43,38 +63,13 @@ public class GameLoginResponseHandler<R>(
     public fun writeSuccessfulResponse(
         response: LoginResponse.Ok,
         loginBlock: LoginBlock<*>,
-    ): Session<R>? {
+    ): Session<R> {
         // Ensure it isn't null - our decoder pre-validates it long before hitting this function,
         // so this exception should never be hit.
         val oldSchoolClientType =
             checkNotNull(loginBlock.clientType.toOldSchoolClientType()) {
                 "Login client type cannot be null"
             }
-        val address = ctx.inetAddress()
-        val count =
-            networkService
-                .iNetAddressHandlers
-                .gameInetAddressTracker
-                .getCount(address)
-        val accepted =
-            networkService
-                .iNetAddressHandlers
-                .inetAddressValidator
-                .acceptGameConnection(address, count)
-        // Secondary validation just before we allow the server to log the user in
-        if (!accepted) {
-            networkLog(logger) {
-                "INetAddressValidator rejected game login for channel ${ctx.channel()}"
-            }
-            ctx
-                .writeAndFlush(LoginResponse.TooManyAttempts)
-                .addListener(ChannelFutureListener.CLOSE)
-            networkService.trafficMonitor.loginChannelTrafficMonitor.addDisconnectionReason(
-                ctx.inetAddress(),
-                LoginDisconnectionReason.GAME_TOO_MANY_ATTEMPTS,
-            )
-            return null
-        }
         val cipher = createStreamCipherPair(loginBlock)
 
         if (networkService.betaWorld) {

--- a/protocol/osrs-227/osrs-227-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-227/osrs-227-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -50,16 +50,6 @@ public class GameLoginResponseHandler<R>(
             checkNotNull(loginBlock.clientType.toOldSchoolClientType()) {
                 "Login client type cannot be null"
             }
-        if (!ctx.channel().isActive) {
-            networkLog(logger) {
-                "Channel '${ctx.channel()}' has gone inactive; login block: $loginBlock"
-            }
-            networkService.trafficMonitor.loginChannelTrafficMonitor.addDisconnectionReason(
-                ctx.inetAddress(),
-                LoginDisconnectionReason.GAME_CHANNEL_INACTIVE,
-            )
-            return null
-        }
         val address = ctx.inetAddress()
         val count =
             networkService
@@ -114,23 +104,13 @@ public class GameLoginResponseHandler<R>(
     public fun writeSuccessfulResponse(
         response: LoginResponse.ReconnectOk,
         loginBlock: LoginBlock<*>,
-    ): Session<R>? {
+    ): Session<R> {
         // Ensure it isn't null - our decoder pre-validates it long before hitting this function,
         // so this exception should never be hit.
         val oldSchoolClientType =
             checkNotNull(loginBlock.clientType.toOldSchoolClientType()) {
                 "Login client type cannot be null"
             }
-        if (!ctx.channel().isActive) {
-            networkLog(logger) {
-                "Channel '${ctx.channel()}' has gone inactive; login block: $loginBlock"
-            }
-            networkService.trafficMonitor.loginChannelTrafficMonitor.addDisconnectionReason(
-                ctx.inetAddress(),
-                LoginDisconnectionReason.GAME_CHANNEL_INACTIVE,
-            )
-            return null
-        }
         val (encodingCipher, decodingCipher) = createStreamCipherPair(loginBlock)
 
         // Unlike in the above case, we kind of have to assume it was successful

--- a/protocol/osrs-227/osrs-227-api/src/main/kotlin/net/rsprot/protocol/api/repositories/MessageDecoderRepositories.kt
+++ b/protocol/osrs-227/osrs-227-api/src/main/kotlin/net/rsprot/protocol/api/repositories/MessageDecoderRepositories.kt
@@ -22,11 +22,12 @@ public class MessageDecoderRepositories private constructor(
     public val gameMessageDecoderRepositories: ClientTypeMap<MessageDecoderRepository<ClientProt>>,
 ) {
     public constructor(
+        clientTypes: List<OldSchoolClientType>,
         exp: BigInteger,
         mod: BigInteger,
         gameMessageDecoderRepositories: ClientTypeMap<MessageDecoderRepository<ClientProt>>,
     ) : this(
-        LoginMessageDecoderRepository.build(exp, mod),
+        LoginMessageDecoderRepository.build(clientTypes, exp, mod),
         Js5MessageDecoderRepository.build(),
         gameMessageDecoderRepositories,
     )
@@ -49,6 +50,7 @@ public class MessageDecoderRepositories private constructor(
                     repositories,
                 )
             return MessageDecoderRepositories(
+                clientTypes,
                 rsaKeyPair.exponent,
                 rsaKeyPair.modulus,
                 clientTypeMap,

--- a/protocol/osrs-227/osrs-227-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/LoginClientType.kt
+++ b/protocol/osrs-227/osrs-227-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/LoginClientType.kt
@@ -1,5 +1,7 @@
 package net.rsprot.protocol.loginprot.incoming.util
 
+import net.rsprot.protocol.common.client.OldSchoolClientType
+
 public enum class LoginClientType(
     public val id: Int,
 ) {
@@ -12,6 +14,18 @@ public enum class LoginClientType(
     ENHANCED_IOS(8),
     ENHANCED_LINUX(10),
     ;
+
+    public fun toOldSchoolClientType(): OldSchoolClientType? {
+        return when (this) {
+            DESKTOP -> OldSchoolClientType.DESKTOP
+            ENHANCED_WINDOWS -> OldSchoolClientType.DESKTOP
+            ENHANCED_LINUX -> OldSchoolClientType.DESKTOP
+            ENHANCED_MAC -> OldSchoolClientType.DESKTOP
+            ENHANCED_ANDROID -> OldSchoolClientType.ANDROID
+            ENHANCED_IOS -> OldSchoolClientType.IOS
+            else -> null
+        }
+    }
 
     public companion object {
         public operator fun get(id: Int): LoginClientType =

--- a/protocol/osrs-227/osrs-227-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameLoginDecoder.kt
+++ b/protocol/osrs-227/osrs-227-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameLoginDecoder.kt
@@ -3,6 +3,7 @@ package net.rsprot.protocol.common.loginprot.incoming.codec
 import net.rsprot.buffer.JagByteBuf
 import net.rsprot.buffer.extensions.toJagByteBuf
 import net.rsprot.protocol.ClientProt
+import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.common.loginprot.incoming.codec.shared.LoginBlockDecoder
 import net.rsprot.protocol.common.loginprot.incoming.prot.LoginClientProt
 import net.rsprot.protocol.loginprot.incoming.GameLogin
@@ -14,6 +15,7 @@ import net.rsprot.protocol.message.codec.MessageDecoder
 import java.math.BigInteger
 
 public class GameLoginDecoder(
+    private val supportedClientTypes: List<OldSchoolClientType>,
     exp: BigInteger,
     mod: BigInteger,
 ) : LoginBlockDecoder<AuthenticationType<*>>(exp, mod),
@@ -25,7 +27,7 @@ public class GameLoginDecoder(
         // Mark the buffer as "read" as copy function doesn't do it automatically.
         buffer.buffer.readerIndex(buffer.buffer.writerIndex())
         return GameLogin(copy.toJagByteBuf()) { jagByteBuf, betaWorld ->
-            decodeLoginBlock(jagByteBuf, betaWorld)
+            decodeLoginBlock(jagByteBuf, betaWorld, supportedClientTypes)
         }
     }
 

--- a/protocol/osrs-227/osrs-227-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameReconnectDecoder.kt
+++ b/protocol/osrs-227/osrs-227-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameReconnectDecoder.kt
@@ -4,6 +4,7 @@ import net.rsprot.buffer.JagByteBuf
 import net.rsprot.buffer.extensions.toJagByteBuf
 import net.rsprot.crypto.xtea.XteaKey
 import net.rsprot.protocol.ClientProt
+import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.common.loginprot.incoming.codec.shared.LoginBlockDecoder
 import net.rsprot.protocol.common.loginprot.incoming.prot.LoginClientProt
 import net.rsprot.protocol.loginprot.incoming.GameReconnect
@@ -11,6 +12,7 @@ import net.rsprot.protocol.message.codec.MessageDecoder
 import java.math.BigInteger
 
 public class GameReconnectDecoder(
+    private val supportedClientTypes: List<OldSchoolClientType>,
     exp: BigInteger,
     mod: BigInteger,
 ) : LoginBlockDecoder<XteaKey>(exp, mod),
@@ -22,7 +24,7 @@ public class GameReconnectDecoder(
         // Mark the buffer as "read" as copy function doesn't do it automatically.
         buffer.buffer.readerIndex(buffer.buffer.writerIndex())
         return GameReconnect(copy.toJagByteBuf()) { jagByteBuf, betaWorld ->
-            decodeLoginBlock(jagByteBuf, betaWorld)
+            decodeLoginBlock(jagByteBuf, betaWorld, supportedClientTypes)
         }
     }
 

--- a/protocol/osrs-227/osrs-227-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/shared/exceptions/UnsupportedClientException.kt
+++ b/protocol/osrs-227/osrs-227-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/shared/exceptions/UnsupportedClientException.kt
@@ -1,0 +1,12 @@
+package net.rsprot.protocol.common.loginprot.incoming.codec.shared.exceptions
+
+/**
+ * A singleton exception for whenever login decoding fails due to an unsupported client connecting to it.
+ * It is not ideal to be using exceptions for flow control, but it is by far the easiest option
+ * here. From a performance standpoint, only building stack traces is slow, which we aren't
+ * going to be doing for this type of exception.
+ */
+public data object UnsupportedClientException : RuntimeException() {
+    @Suppress("unused")
+    private fun readResolve(): Any = UnsupportedClientException
+}

--- a/protocol/osrs-227/osrs-227-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/prot/LoginMessageDecoderRepository.kt
+++ b/protocol/osrs-227/osrs-227-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/prot/LoginMessageDecoderRepository.kt
@@ -1,6 +1,7 @@
 package net.rsprot.protocol.common.loginprot.incoming.prot
 
 import net.rsprot.protocol.ProtRepository
+import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.common.loginprot.incoming.codec.GameLoginDecoder
 import net.rsprot.protocol.common.loginprot.incoming.codec.GameReconnectDecoder
 import net.rsprot.protocol.common.loginprot.incoming.codec.InitGameConnectionDecoder
@@ -14,6 +15,7 @@ import java.math.BigInteger
 public object LoginMessageDecoderRepository {
     @ExperimentalStdlibApi
     public fun build(
+        supportedClientTypes: List<OldSchoolClientType>,
         exp: BigInteger,
         mod: BigInteger,
     ): MessageDecoderRepository<LoginClientProt> {
@@ -24,8 +26,8 @@ public object LoginMessageDecoderRepository {
             ).apply {
                 bind(InitGameConnectionDecoder())
                 bind(InitJs5RemoteConnectionDecoder())
-                bind(GameLoginDecoder(exp, mod))
-                bind(GameReconnectDecoder(exp, mod))
+                bind(GameLoginDecoder(supportedClientTypes, exp, mod))
+                bind(GameReconnectDecoder(supportedClientTypes, exp, mod))
                 bind(ProofOfWorkReplyDecoder())
                 bind(RemainingBetaArchivesDecoder())
             }

--- a/protocol/osrs-228/osrs-228-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-228/osrs-228-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -35,6 +35,26 @@ public class GameLoginResponseHandler<R>(
     public val ctx: ChannelHandlerContext,
 ) {
     /**
+     * Validates the new connection by ensuring the connected user hasn't reached an IP limitation due
+     * to too many connections from the same IP.
+     * This function does not write any response to the client. It simply returns whether a new connection
+     * is allowed to take place. The server is responsible for writing the [LoginResponse.TooManyAttempts]
+     * response back to the client via [writeFailedResponse], should they wish to do so.
+     */
+    public fun validateNewConnection(): Boolean {
+        val address = ctx.inetAddress()
+        val count =
+            networkService
+                .iNetAddressHandlers
+                .gameInetAddressTracker
+                .getCount(address)
+        return networkService
+            .iNetAddressHandlers
+            .inetAddressValidator
+            .acceptGameConnection(address, count)
+    }
+
+    /**
      * Writes a successful login response to the client.
      * @param response the login response to write
      * @param loginBlock the login request that the client initially made
@@ -43,38 +63,13 @@ public class GameLoginResponseHandler<R>(
     public fun writeSuccessfulResponse(
         response: LoginResponse.Ok,
         loginBlock: LoginBlock<*>,
-    ): Session<R>? {
+    ): Session<R> {
         // Ensure it isn't null - our decoder pre-validates it long before hitting this function,
         // so this exception should never be hit.
         val oldSchoolClientType =
             checkNotNull(loginBlock.clientType.toOldSchoolClientType()) {
                 "Login client type cannot be null"
             }
-        val address = ctx.inetAddress()
-        val count =
-            networkService
-                .iNetAddressHandlers
-                .gameInetAddressTracker
-                .getCount(address)
-        val accepted =
-            networkService
-                .iNetAddressHandlers
-                .inetAddressValidator
-                .acceptGameConnection(address, count)
-        // Secondary validation just before we allow the server to log the user in
-        if (!accepted) {
-            networkLog(logger) {
-                "INetAddressValidator rejected game login for channel ${ctx.channel()}"
-            }
-            ctx
-                .writeAndFlush(LoginResponse.TooManyAttempts)
-                .addListener(ChannelFutureListener.CLOSE)
-            networkService.trafficMonitor.loginChannelTrafficMonitor.addDisconnectionReason(
-                ctx.inetAddress(),
-                LoginDisconnectionReason.GAME_TOO_MANY_ATTEMPTS,
-            )
-            return null
-        }
         val cipher = createStreamCipherPair(loginBlock)
 
         if (networkService.betaWorld) {

--- a/protocol/osrs-228/osrs-228-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
+++ b/protocol/osrs-228/osrs-228-api/src/main/kotlin/net/rsprot/protocol/api/login/GameLoginResponseHandler.kt
@@ -50,16 +50,6 @@ public class GameLoginResponseHandler<R>(
             checkNotNull(loginBlock.clientType.toOldSchoolClientType()) {
                 "Login client type cannot be null"
             }
-        if (!ctx.channel().isActive) {
-            networkLog(logger) {
-                "Channel '${ctx.channel()}' has gone inactive; login block: $loginBlock"
-            }
-            networkService.trafficMonitor.loginChannelTrafficMonitor.addDisconnectionReason(
-                ctx.inetAddress(),
-                LoginDisconnectionReason.GAME_CHANNEL_INACTIVE,
-            )
-            return null
-        }
         val address = ctx.inetAddress()
         val count =
             networkService
@@ -114,23 +104,13 @@ public class GameLoginResponseHandler<R>(
     public fun writeSuccessfulResponse(
         response: LoginResponse.ReconnectOk,
         loginBlock: LoginBlock<*>,
-    ): Session<R>? {
+    ): Session<R> {
         // Ensure it isn't null - our decoder pre-validates it long before hitting this function,
         // so this exception should never be hit.
         val oldSchoolClientType =
             checkNotNull(loginBlock.clientType.toOldSchoolClientType()) {
                 "Login client type cannot be null"
             }
-        if (!ctx.channel().isActive) {
-            networkLog(logger) {
-                "Channel '${ctx.channel()}' has gone inactive; login block: $loginBlock"
-            }
-            networkService.trafficMonitor.loginChannelTrafficMonitor.addDisconnectionReason(
-                ctx.inetAddress(),
-                LoginDisconnectionReason.GAME_CHANNEL_INACTIVE,
-            )
-            return null
-        }
         val (encodingCipher, decodingCipher) = createStreamCipherPair(loginBlock)
 
         // Unlike in the above case, we kind of have to assume it was successful

--- a/protocol/osrs-228/osrs-228-api/src/main/kotlin/net/rsprot/protocol/api/repositories/MessageDecoderRepositories.kt
+++ b/protocol/osrs-228/osrs-228-api/src/main/kotlin/net/rsprot/protocol/api/repositories/MessageDecoderRepositories.kt
@@ -22,11 +22,12 @@ public class MessageDecoderRepositories private constructor(
     public val gameMessageDecoderRepositories: ClientTypeMap<MessageDecoderRepository<ClientProt>>,
 ) {
     public constructor(
+        clientTypes: List<OldSchoolClientType>,
         exp: BigInteger,
         mod: BigInteger,
         gameMessageDecoderRepositories: ClientTypeMap<MessageDecoderRepository<ClientProt>>,
     ) : this(
-        LoginMessageDecoderRepository.build(exp, mod),
+        LoginMessageDecoderRepository.build(clientTypes, exp, mod),
         Js5MessageDecoderRepository.build(),
         gameMessageDecoderRepositories,
     )
@@ -49,6 +50,7 @@ public class MessageDecoderRepositories private constructor(
                     repositories,
                 )
             return MessageDecoderRepositories(
+                clientTypes,
                 rsaKeyPair.exponent,
                 rsaKeyPair.modulus,
                 clientTypeMap,

--- a/protocol/osrs-228/osrs-228-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/LoginClientType.kt
+++ b/protocol/osrs-228/osrs-228-model/src/main/kotlin/net/rsprot/protocol/loginprot/incoming/util/LoginClientType.kt
@@ -1,5 +1,7 @@
 package net.rsprot.protocol.loginprot.incoming.util
 
+import net.rsprot.protocol.common.client.OldSchoolClientType
+
 public enum class LoginClientType(
     public val id: Int,
 ) {
@@ -12,6 +14,18 @@ public enum class LoginClientType(
     ENHANCED_IOS(8),
     ENHANCED_LINUX(10),
     ;
+
+    public fun toOldSchoolClientType(): OldSchoolClientType? {
+        return when (this) {
+            DESKTOP -> OldSchoolClientType.DESKTOP
+            ENHANCED_WINDOWS -> OldSchoolClientType.DESKTOP
+            ENHANCED_LINUX -> OldSchoolClientType.DESKTOP
+            ENHANCED_MAC -> OldSchoolClientType.DESKTOP
+            ENHANCED_ANDROID -> OldSchoolClientType.ANDROID
+            ENHANCED_IOS -> OldSchoolClientType.IOS
+            else -> null
+        }
+    }
 
     public companion object {
         public operator fun get(id: Int): LoginClientType =

--- a/protocol/osrs-228/osrs-228-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameLoginDecoder.kt
+++ b/protocol/osrs-228/osrs-228-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameLoginDecoder.kt
@@ -3,6 +3,7 @@ package net.rsprot.protocol.common.loginprot.incoming.codec
 import net.rsprot.buffer.JagByteBuf
 import net.rsprot.buffer.extensions.toJagByteBuf
 import net.rsprot.protocol.ClientProt
+import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.common.loginprot.incoming.codec.shared.LoginBlockDecoder
 import net.rsprot.protocol.common.loginprot.incoming.prot.LoginClientProt
 import net.rsprot.protocol.loginprot.incoming.GameLogin
@@ -14,6 +15,7 @@ import net.rsprot.protocol.message.codec.MessageDecoder
 import java.math.BigInteger
 
 public class GameLoginDecoder(
+    private val supportedClientTypes: List<OldSchoolClientType>,
     exp: BigInteger,
     mod: BigInteger,
 ) : LoginBlockDecoder<AuthenticationType<*>>(exp, mod),
@@ -25,7 +27,7 @@ public class GameLoginDecoder(
         // Mark the buffer as "read" as copy function doesn't do it automatically.
         buffer.buffer.readerIndex(buffer.buffer.writerIndex())
         return GameLogin(copy.toJagByteBuf()) { jagByteBuf, betaWorld ->
-            decodeLoginBlock(jagByteBuf, betaWorld)
+            decodeLoginBlock(jagByteBuf, betaWorld, supportedClientTypes)
         }
     }
 

--- a/protocol/osrs-228/osrs-228-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameReconnectDecoder.kt
+++ b/protocol/osrs-228/osrs-228-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/GameReconnectDecoder.kt
@@ -4,6 +4,7 @@ import net.rsprot.buffer.JagByteBuf
 import net.rsprot.buffer.extensions.toJagByteBuf
 import net.rsprot.crypto.xtea.XteaKey
 import net.rsprot.protocol.ClientProt
+import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.common.loginprot.incoming.codec.shared.LoginBlockDecoder
 import net.rsprot.protocol.common.loginprot.incoming.prot.LoginClientProt
 import net.rsprot.protocol.loginprot.incoming.GameReconnect
@@ -11,6 +12,7 @@ import net.rsprot.protocol.message.codec.MessageDecoder
 import java.math.BigInteger
 
 public class GameReconnectDecoder(
+    private val supportedClientTypes: List<OldSchoolClientType>,
     exp: BigInteger,
     mod: BigInteger,
 ) : LoginBlockDecoder<XteaKey>(exp, mod),
@@ -22,7 +24,7 @@ public class GameReconnectDecoder(
         // Mark the buffer as "read" as copy function doesn't do it automatically.
         buffer.buffer.readerIndex(buffer.buffer.writerIndex())
         return GameReconnect(copy.toJagByteBuf()) { jagByteBuf, betaWorld ->
-            decodeLoginBlock(jagByteBuf, betaWorld)
+            decodeLoginBlock(jagByteBuf, betaWorld, supportedClientTypes)
         }
     }
 

--- a/protocol/osrs-228/osrs-228-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/shared/exceptions/UnsupportedClientException.kt
+++ b/protocol/osrs-228/osrs-228-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/codec/shared/exceptions/UnsupportedClientException.kt
@@ -1,0 +1,12 @@
+package net.rsprot.protocol.common.loginprot.incoming.codec.shared.exceptions
+
+/**
+ * A singleton exception for whenever login decoding fails due to an unsupported client connecting to it.
+ * It is not ideal to be using exceptions for flow control, but it is by far the easiest option
+ * here. From a performance standpoint, only building stack traces is slow, which we aren't
+ * going to be doing for this type of exception.
+ */
+public data object UnsupportedClientException : RuntimeException() {
+    @Suppress("unused")
+    private fun readResolve(): Any = UnsupportedClientException
+}

--- a/protocol/osrs-228/osrs-228-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/prot/LoginMessageDecoderRepository.kt
+++ b/protocol/osrs-228/osrs-228-shared/src/main/kotlin/net/rsprot/protocol/common/loginprot/incoming/prot/LoginMessageDecoderRepository.kt
@@ -1,6 +1,7 @@
 package net.rsprot.protocol.common.loginprot.incoming.prot
 
 import net.rsprot.protocol.ProtRepository
+import net.rsprot.protocol.common.client.OldSchoolClientType
 import net.rsprot.protocol.common.loginprot.incoming.codec.GameLoginDecoder
 import net.rsprot.protocol.common.loginprot.incoming.codec.GameReconnectDecoder
 import net.rsprot.protocol.common.loginprot.incoming.codec.InitGameConnectionDecoder
@@ -14,6 +15,7 @@ import java.math.BigInteger
 public object LoginMessageDecoderRepository {
     @ExperimentalStdlibApi
     public fun build(
+        supportedClientTypes: List<OldSchoolClientType>,
         exp: BigInteger,
         mod: BigInteger,
     ): MessageDecoderRepository<LoginClientProt> {
@@ -24,8 +26,8 @@ public object LoginMessageDecoderRepository {
             ).apply {
                 bind(InitGameConnectionDecoder())
                 bind(InitJs5RemoteConnectionDecoder())
-                bind(GameLoginDecoder(exp, mod))
-                bind(GameReconnectDecoder(exp, mod))
+                bind(GameLoginDecoder(supportedClientTypes, exp, mod))
+                bind(GameReconnectDecoder(supportedClientTypes, exp, mod))
                 bind(ProofOfWorkReplyDecoder())
                 bind(RemainingBetaArchivesDecoder())
             }


### PR DESCRIPTION
Changes the GameLoginResponseHandler#writeSuccessfulResponse function to return a non-nullable Session.

The old implementation performed certain checks in the writeSuccessfulResponse functions, which meant it could fail and return null. This however lead to some annoying server-side code, as servers had to allocate a slot in the world for the player, try to send it to the client, then continue on normally if it succeeded, and de-allocate if it failed.

The client type check has been migrated to occur during login block decoding - if it fails, the login block itself will not even be decoded (no RSA-decrypting etc), actually improving one potential attack vector.
The activity check has been removed as it happens in plenty of situations after it, and the connection limit has been migrated to its own function, meaning servers will have to implement it themselves now.