### PR TITLE
fix: expose private constructor in rebuild region zone

### DIFF
--- a/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/RebuildRegion.kt
+++ b/protocol/osrs-221/osrs-221-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/RebuildRegion.kt
@@ -116,7 +116,7 @@ public class RebuildRegion private constructor(
      * @property referenceZone the zone to be copied from the static map
      * @property key the xtea key needed to decrypt the locs file in the cache of that respective mapsquare
      */
-    public class RebuildRegionZone private constructor(
+    public class RebuildRegionZone public constructor(
         public val referenceZone: ReferenceZone,
         public val key: XteaKey,
     ) {

--- a/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/util/RebuildRegionZone.kt
+++ b/protocol/osrs-222/osrs-222-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/util/RebuildRegionZone.kt
@@ -8,7 +8,7 @@ import net.rsprot.crypto.xtea.XteaKey
  * @property referenceZone the zone to be copied from the static map
  * @property key the xtea key needed to decrypt the locs file in the cache of that respective mapsquare
  */
-public class RebuildRegionZone private constructor(
+public class RebuildRegionZone public constructor(
     public val referenceZone: ReferenceZone,
     public val key: XteaKey,
 ) {

--- a/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/util/RebuildRegionZone.kt
+++ b/protocol/osrs-223/osrs-223-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/util/RebuildRegionZone.kt
@@ -8,7 +8,7 @@ import net.rsprot.crypto.xtea.XteaKey
  * @property referenceZone the zone to be copied from the static map
  * @property key the xtea key needed to decrypt the locs file in the cache of that respective mapsquare
  */
-public class RebuildRegionZone private constructor(
+public class RebuildRegionZone public constructor(
     public val referenceZone: ReferenceZone,
     public val key: XteaKey,
 ) {

--- a/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/util/RebuildRegionZone.kt
+++ b/protocol/osrs-224/osrs-224-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/util/RebuildRegionZone.kt
@@ -8,7 +8,7 @@ import net.rsprot.crypto.xtea.XteaKey
  * @property referenceZone the zone to be copied from the static map
  * @property key the xtea key needed to decrypt the locs file in the cache of that respective mapsquare
  */
-public class RebuildRegionZone private constructor(
+public class RebuildRegionZone public constructor(
     public val referenceZone: ReferenceZone,
     public val key: XteaKey,
 ) {

--- a/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/util/RebuildRegionZone.kt
+++ b/protocol/osrs-225/osrs-225-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/util/RebuildRegionZone.kt
@@ -8,7 +8,7 @@ import net.rsprot.crypto.xtea.XteaKey
  * @property referenceZone the zone to be copied from the static map
  * @property key the xtea key needed to decrypt the locs file in the cache of that respective mapsquare
  */
-public class RebuildRegionZone private constructor(
+public class RebuildRegionZone public constructor(
     public val referenceZone: ReferenceZone,
     public val key: XteaKey,
 ) {

--- a/protocol/osrs-226/osrs-226-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/util/RebuildRegionZone.kt
+++ b/protocol/osrs-226/osrs-226-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/util/RebuildRegionZone.kt
@@ -8,7 +8,7 @@ import net.rsprot.crypto.xtea.XteaKey
  * @property referenceZone the zone to be copied from the static map
  * @property key the xtea key needed to decrypt the locs file in the cache of that respective mapsquare
  */
-public class RebuildRegionZone private constructor(
+public class RebuildRegionZone public constructor(
     public val referenceZone: ReferenceZone,
     public val key: XteaKey,
 ) {

--- a/protocol/osrs-227/osrs-227-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/util/RebuildRegionZone.kt
+++ b/protocol/osrs-227/osrs-227-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/util/RebuildRegionZone.kt
@@ -8,7 +8,7 @@ import net.rsprot.crypto.xtea.XteaKey
  * @property referenceZone the zone to be copied from the static map
  * @property key the xtea key needed to decrypt the locs file in the cache of that respective mapsquare
  */
-public class RebuildRegionZone private constructor(
+public class RebuildRegionZone public constructor(
     public val referenceZone: ReferenceZone,
     public val key: XteaKey,
 ) {

--- a/protocol/osrs-228/osrs-228-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/util/RebuildRegionZone.kt
+++ b/protocol/osrs-228/osrs-228-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/map/util/RebuildRegionZone.kt
@@ -8,7 +8,7 @@ import net.rsprot.crypto.xtea.XteaKey
  * @property referenceZone the zone to be copied from the static map
  * @property key the xtea key needed to decrypt the locs file in the cache of that respective mapsquare
  */
-public class RebuildRegionZone private constructor(
+public class RebuildRegionZone public constructor(
     public val referenceZone: ReferenceZone,
     public val key: XteaKey,
 ) {


### PR DESCRIPTION
As a followup to: https://github.com/blurite/rsprot/commit/0e971361558a9627eef0fdfc4d43a55874015365

This would allow direct passing of the created ReferenceZones from the previous changes.