### PR TITLE
fix: alt pdata methods to add 128

### DIFF
--- a/buffer/src/main/kotlin/net/rsprot/buffer/extensions/JagexByteBufExtensions.kt
+++ b/buffer/src/main/kotlin/net/rsprot/buffer/extensions/JagexByteBufExtensions.kt
@@ -722,7 +722,7 @@ public fun ByteBuf.pdataAlt2(
     length: Int = data.size,
 ): ByteBuf {
     for (i in offset..<(offset + length)) {
-        writeByte(data[i].toInt() - HALF_UBYTE)
+        writeByte(data[i].toInt() + HALF_UBYTE)
     }
     return this
 }
@@ -733,7 +733,7 @@ public fun ByteBuf.pdataAlt2(
     length: Int = data.readableBytes(),
 ): ByteBuf {
     for (i in offset..<(offset + length)) {
-        writeByte(data.getByte(i) - HALF_UBYTE)
+        writeByte(data.getByte(i) + HALF_UBYTE)
     }
     return this
 }
@@ -764,7 +764,7 @@ public fun ByteBuf.pdataAlt3(
     length: Int = data.size,
 ): ByteBuf {
     for (i in (offset + length - 1) downTo offset) {
-        writeByte(data[i].toInt() - HALF_UBYTE)
+        writeByte(data[i].toInt() + HALF_UBYTE)
     }
     return this
 }
@@ -775,7 +775,7 @@ public fun ByteBuf.pdataAlt3(
     length: Int = data.readableBytes(),
 ): ByteBuf {
     for (i in (offset + length - 1) downTo offset) {
-        writeByte(data.getByte(i) - HALF_UBYTE)
+        writeByte(data.getByte(i) + HALF_UBYTE)
     }
     return this
 }


### PR DESCRIPTION
pretty sure these were flipped. 
pdata its the linear array no transforms
alt1 is reverse order no transforms
alt2 is linear with alt1/add128
alt 3 is reverse with alt1/add128

this matches with the gdata methods for the order except alt2/3 sub128 rather than add.