### PR TITLE
Fix r237 high-resolution world entity mask framing

### DIFF
--- a/protocol/osrs-237/osrs-237-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/worldentity/extendedinfo/WorldEntityAvatarExtendedInfoDesktopWriter.kt
+++ b/protocol/osrs-237/osrs-237-desktop/src/main/kotlin/net/rsprot/protocol/game/outgoing/codec/worldentity/extendedinfo/WorldEntityAvatarExtendedInfoDesktopWriter.kt
@@ -5,16 +5,16 @@ package net.rsprot.protocol.game.outgoing.codec.worldentity.extendedinfo
 import com.github.michaelbull.logging.InlineLogger
 import net.rsprot.buffer.JagByteBuf
 import net.rsprot.protocol.common.client.OldSchoolClientType
-import net.rsprot.protocol.game.outgoing.info.AvatarExtendedInfoWriter
 import net.rsprot.protocol.game.outgoing.info.worldentityinfo.WorldEntityAvatarExtendedInfo
 import net.rsprot.protocol.game.outgoing.info.worldentityinfo.WorldEntityAvatarExtendedInfoBlocks
+import net.rsprot.protocol.game.outgoing.info.worldentityinfo.WorldEntityAvatarExtendedInfoWriter
 import net.rsprot.protocol.internal.game.outgoing.info.ExtendedInfo
 import net.rsprot.protocol.internal.game.outgoing.info.encoder.OnDemandExtendedInfoEncoder
 import net.rsprot.protocol.internal.game.outgoing.info.encoder.PrecomputedExtendedInfoEncoder
 import net.rsprot.protocol.internal.game.outgoing.info.worldentityinfo.encoder.WorldEntityExtendedInfoEncoders
 
 public class WorldEntityAvatarExtendedInfoDesktopWriter :
-    AvatarExtendedInfoWriter<WorldEntityExtendedInfoEncoders, WorldEntityAvatarExtendedInfoBlocks>(
+    WorldEntityAvatarExtendedInfoWriter(
         OldSchoolClientType.DESKTOP,
         WorldEntityExtendedInfoEncoders(
             OldSchoolClientType.DESKTOP,
@@ -41,6 +41,7 @@ public class WorldEntityAvatarExtendedInfoDesktopWriter :
         flag: Int,
         blocks: WorldEntityAvatarExtendedInfoBlocks,
         flagWriteIndex: Int,
+        resolutionUpgrade: Boolean,
     ) {
         val clientFlag = convertFlags(flag)
         var outFlag = clientFlag
@@ -50,7 +51,11 @@ public class WorldEntityAvatarExtendedInfoDesktopWriter :
 
         val finalPos = buffer.writerIndex()
         buffer.writerIndex(flagWriteIndex)
-        buffer.p1Alt3(outFlag)
+        if (resolutionUpgrade) {
+            buffer.p1Alt3(outFlag)
+        } else {
+            buffer.p1(outFlag)
+        }
         buffer.writerIndex(finalPos)
     }
 

--- a/protocol/osrs-237/osrs-237-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityAvatarExtendedInfo.kt
+++ b/protocol/osrs-237/osrs-237-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityAvatarExtendedInfo.kt
@@ -11,8 +11,45 @@ import net.rsprot.protocol.internal.game.outgoing.info.precompute
 import net.rsprot.protocol.internal.game.outgoing.info.shared.extendedinfo.VisibleOps
 import net.rsprot.protocol.internal.game.outgoing.info.worldentityinfo.encoder.WorldEntityExtendedInfoEncoders
 
-public typealias WorldEntityAvatarExtendedInfoWriter =
-    AvatarExtendedInfoWriter<WorldEntityExtendedInfoEncoders, WorldEntityAvatarExtendedInfoBlocks>
+/**
+ * A base class for client-specific world entity extended info writers.
+ */
+public abstract class WorldEntityAvatarExtendedInfoWriter(
+    oldSchoolClientType: OldSchoolClientType,
+    encoders: WorldEntityExtendedInfoEncoders,
+) : AvatarExtendedInfoWriter<WorldEntityExtendedInfoEncoders, WorldEntityAvatarExtendedInfoBlocks>(
+        oldSchoolClientType,
+        encoders,
+    ) {
+    final override fun pExtendedInfo(
+        buffer: JagByteBuf,
+        localIndex: Int,
+        observerIndex: Int,
+        flag: Int,
+        blocks: WorldEntityAvatarExtendedInfoBlocks,
+        flagWriteIndex: Int,
+    ) {
+        pExtendedInfo(
+            buffer,
+            localIndex,
+            observerIndex,
+            flag,
+            blocks,
+            flagWriteIndex,
+            resolutionUpgrade = true,
+        )
+    }
+
+    public abstract fun pExtendedInfo(
+        buffer: JagByteBuf,
+        localIndex: Int,
+        observerIndex: Int,
+        flag: Int,
+        blocks: WorldEntityAvatarExtendedInfoBlocks,
+        flagWriteIndex: Int,
+        resolutionUpgrade: Boolean,
+    )
+}
 
 /**
  * World entity avatar extended info is a data structure used to keep track of all the extended info
@@ -145,6 +182,7 @@ public class WorldEntityAvatarExtendedInfo(
         observerIndex: Int,
         extraFlag: Int,
         flagWriteIndex: Int,
+        resolutionUpgrade: Boolean,
     ) {
         val flag = this.flags or extraFlag
         val writer =
@@ -159,6 +197,7 @@ public class WorldEntityAvatarExtendedInfo(
             flag,
             blocks,
             flagWriteIndex,
+            resolutionUpgrade,
         )
     }
 

--- a/protocol/osrs-237/osrs-237-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityInfo.kt
+++ b/protocol/osrs-237/osrs-237-model/src/main/kotlin/net/rsprot/protocol/game/outgoing/info/worldentityinfo/WorldEntityInfo.kt
@@ -326,7 +326,12 @@ public class WorldEntityInfo internal constructor(
                 precomputedBuffer.readableBytes(),
             )
             val placeholderFlag = pPlaceholderExtendedInfoFlag(buffer)
-            putWorldEntityExtendedInfo(avatar, buffer, placeholderFlag)
+            putWorldEntityExtendedInfo(
+                avatar,
+                buffer,
+                placeholderFlag,
+                resolutionUpgrade = false,
+            )
         }
         return count != this.highResolutionIndicesCount
     }
@@ -429,7 +434,12 @@ public class WorldEntityInfo internal constructor(
                 avatar.currentCoordFine.z - fineZOffset,
                 avatar.angle,
             )
-            putWorldEntityExtendedInfo(avatar, buffer, placeholderFlag)
+            putWorldEntityExtendedInfo(
+                avatar,
+                buffer,
+                placeholderFlag,
+                resolutionUpgrade = true,
+            )
         }
     }
 
@@ -443,6 +453,7 @@ public class WorldEntityInfo internal constructor(
         avatar: WorldEntityAvatar,
         buffer: JagByteBuf,
         flagWriteIndex: Int,
+        resolutionUpgrade: Boolean,
     ) {
         // No extra flags right now as the extended info system is still primitive
         avatar.extendedInfo.pExtendedInfo(
@@ -451,6 +462,7 @@ public class WorldEntityInfo internal constructor(
             localIndex,
             0,
             flagWriteIndex,
+            resolutionUpgrade,
         )
     }
 


### PR DESCRIPTION
## Summary

Revision 237 uses transformed byte for low to high resolution transition.
This PR explicitly marks the change.

I can make this generic across protocols since it likely is something that was missed.